### PR TITLE
feat: add Feishu (Lark) channel with WebSocket long connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
 
 **The world's first AI assistant(OpenClaw) on a $5 chip. No Linux. No Node.js. Just pure C**
 
-MimiClaw turns a tiny ESP32-S3 board into a personal AI assistant. Plug it into USB power, connect to WiFi, and talk to it through Telegram — it handles any task you throw at it and evolves over time with local memory — all on a chip the size of a thumb.
+MimiClaw turns a tiny ESP32-S3 board into a personal AI assistant. Plug it into USB power, connect to WiFi, and talk to it through Telegram or Feishu — it handles any task you throw at it and evolves over time with local memory — all on a chip the size of a thumb.
 
 ## Meet MimiClaw
 
 - **Tiny** — No Linux, no Node.js, no bloat — just pure C
-- **Handy** — Message it from Telegram, it handles the rest
+- **Handy** — Message it from Telegram or Feishu, it handles the rest
 - **Loyal** — Learns from memory, remembers across reboots
 - **Energetic** — USB power, 0.5 W, runs 24/7
 - **Lovable** — One ESP32-S3 board, $5, nothing else
@@ -31,8 +31,9 @@ MimiClaw turns a tiny ESP32-S3 board into a personal AI assistant. Plug it into 
  │ Channels  │     │  Message   │     │  Claude  │     │  Tools  │  │
  │           │────▶│  Queue     │────▶│  (LLM)   │────▶│         │──┘
  │ Telegram  │     └───────────┘     └────┬─────┘     └────┬────┘
- │ WebSocket │◀──────────────────────────-│                │
- └───────────┘        Response            │                │
+ │ Feishu    │◀──────────────────────────-│                │
+ │ WebSocket │        Response            │                │
+ └───────────┘                            │                │
                                     ┌─────▼────────────────▼────┐
                                     │        Context            │
                                     │  ┌──────────┐ ┌────────┐  │
@@ -45,7 +46,7 @@ MimiClaw turns a tiny ESP32-S3 board into a personal AI assistant. Plug it into 
                                           ESP32-S3 Flash
 ```
 
-You send a message on Telegram. The ESP32-S3 picks it up over WiFi, feeds it into an agent loop — Claude thinks, calls tools, reads memory — and sends the reply back. Everything runs on a single $5 chip with all your data stored locally on flash.
+You send a message on Telegram or Feishu. The ESP32-S3 picks it up over WiFi, feeds it into an agent loop — Claude thinks, calls tools, reads memory — and sends the reply back. Everything runs on a single $5 chip with all your data stored locally on flash.
 
 ## Quick Start
 
@@ -53,7 +54,7 @@ You send a message on Telegram. The ESP32-S3 picks it up over WiFi, feeds it int
 
 - An **ESP32-S3 dev board** with 16 MB flash and 8 MB PSRAM (e.g. Xiaozhi AI board, ~$10)
 - A **USB Type-C cable**
-- A **Telegram bot token** — talk to [@BotFather](https://t.me/BotFather) on Telegram to create one
+- A **Telegram bot token** — talk to [@BotFather](https://t.me/BotFather) on Telegram to create one (or use [Feishu](docs/FEISHU.md) instead)
 - An **Anthropic API key** — from [console.anthropic.com](https://console.anthropic.com)
 
 ### Install
@@ -117,6 +118,8 @@ mimi> set_model claude-sonnet-4-5  # change LLM model
 mimi> set_proxy 127.0.0.1 7897  # set HTTP proxy
 mimi> clear_proxy                  # remove proxy
 mimi> set_search_key BSA...        # set Brave Search API key
+mimi> set_feishu_id cli_xxx        # set Feishu App ID
+mimi> set_feishu_secret xxx        # set Feishu App Secret
 mimi> config_show                  # show all config (masked)
 mimi> config_reset                 # clear NVS, revert to build-time defaults
 ```
@@ -158,6 +161,7 @@ To enable web search, set a [Brave Search API key](https://brave.com/search/api/
 
 ## Also Included
 
+- **Feishu (Lark)** — [connect via Feishu](docs/FEISHU.md) using WebSocket long connection, no public IP needed
 - **WebSocket gateway** on port 18789 — connect from your LAN with any WebSocket client
 - **OTA updates** — flash new firmware over WiFi, no USB needed
 - **Dual-core** — network I/O and AI processing run on separate CPU cores
@@ -169,6 +173,7 @@ To enable web search, set a [Brave Search API key](https://brave.com/search/api/
 Technical details live in the `docs/` folder:
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — system design, module map, task layout, memory budget, protocols, flash partitions
+- **[docs/FEISHU.md](docs/FEISHU.md)** — Feishu (Lark) setup guide
 - **[docs/TODO.md](docs/TODO.md)** — feature gap tracker and roadmap
 
 ## License

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,12 +12,12 @@
 
 **$5 芯片上的 AI 助理（OpenClaw）。没有 Linux，没有 Node.js，纯 C。**
 
-MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插上 USB 供电，连上 WiFi，通过 Telegram 跟它对话 — 它能处理你丢给它的任何任务，还会随时间积累本地记忆不断进化 — 全部跑在一颗拇指大小的芯片上。
+MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插上 USB 供电，连上 WiFi，通过 Telegram 或飞书跟它对话 — 它能处理你丢给它的任何任务，还会随时间积累本地记忆不断进化 — 全部跑在一颗拇指大小的芯片上。
 
 ## 认识 MimiClaw
 
 - **小巧** — 没有 Linux，没有 Node.js，没有臃肿依赖 — 纯 C
-- **好用** — 在 Telegram 发消息，剩下的它来搞定
+- **好用** — 在 Telegram 或飞书发消息，剩下的它来搞定
 - **忠诚** — 从记忆中学习，跨重启也不会忘
 - **能干** — USB 供电，0.5W，24/7 运行
 - **可爱** — 一块 ESP32-S3 开发板，$5，没了
@@ -31,8 +31,9 @@ MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插
  │ Channels  │     │  Message   │     │  Claude  │     │  Tools  │  │
  │           │────▶│  Queue     │────▶│  (LLM)   │────▶│         │──┘
  │ Telegram  │     └───────────┘     └────┬─────┘     └────┬────┘
- │ WebSocket │◀──────────────────────────-│                │
- └───────────┘        Response            │                │
+ │ Feishu    │◀──────────────────────────-│                │
+ │ WebSocket │        Response            │                │
+ └───────────┘                            │                │
                                     ┌─────▼────────────────▼────┐
                                     │        Context            │
                                     │  ┌──────────┐ ┌────────┐  │
@@ -45,7 +46,7 @@ MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插
                                           ESP32-S3 Flash
 ```
 
-你在 Telegram 发一条消息，ESP32-S3 通过 WiFi 收到后送进 Agent 循环 — Claude 思考、调用工具、读取记忆 — 再把回复发回来。一切都跑在一颗 $5 的芯片上，所有数据存在本地 Flash。
+你在 Telegram 或飞书发一条消息，ESP32-S3 通过 WiFi 收到后送进 Agent 循环 — Claude 思考、调用工具、读取记忆 — 再把回复发回来。一切都跑在一颗 $5 的芯片上，所有数据存在本地 Flash。
 
 ## 快速开始
 
@@ -53,7 +54,7 @@ MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插
 
 - 一块 **ESP32-S3 开发板**，16MB Flash + 8MB PSRAM（如小智 AI 开发板，~¥30）
 - 一根 **USB Type-C 数据线**
-- 一个 **Telegram Bot Token** — 在 Telegram 找 [@BotFather](https://t.me/BotFather) 创建
+- 一个 **Telegram Bot Token** — 在 Telegram 找 [@BotFather](https://t.me/BotFather) 创建（或使用[飞书](docs/FEISHU.md)）
 - 一个 **Anthropic API Key** — 从 [console.anthropic.com](https://console.anthropic.com) 获取
 
 ### 安装
@@ -132,6 +133,8 @@ mimi> set_model claude-sonnet-4-5-20250929  # 换模型
 mimi> set_proxy 192.168.1.83 7897  # 设置代理
 mimi> clear_proxy                  # 清除代理
 mimi> set_search_key BSA...        # 设置 Brave Search API Key
+mimi> set_feishu_id cli_xxx        # 设置飞书 App ID
+mimi> set_feishu_secret xxx        # 设置飞书 App Secret
 mimi> config_show                  # 查看所有配置（脱敏显示）
 mimi> config_reset                 # 清除 NVS，恢复编译时默认值
 ```
@@ -173,6 +176,7 @@ MimiClaw 使用 Anthropic 的 tool use 协议 — Claude 在对话中可以调�
 
 ## 其他功能
 
+- **飞书** — [通过飞书连接](docs/FEISHU.md)，WebSocket 长连接，不需要公网 IP
 - **WebSocket 网关** — 端口 18789，局域网内用任意 WebSocket 客户端连接
 - **OTA 更新** — WiFi 远程刷固件，无需 USB
 - **双核** — 网络 I/O 和 AI 处理分别跑在不同 CPU 核心
@@ -184,6 +188,7 @@ MimiClaw 使用 Anthropic 的 tool use 协议 — Claude 在对话中可以调�
 技术细节在 `docs/` 文件夹：
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — 系统设计、模块划分、任务布局、内存分配、协议、Flash 分区
+- **[docs/FEISHU.md](docs/FEISHU.md)** — 飞书配置指南
 - **[docs/TODO.md](docs/TODO.md)** — 功能差距和路线图
 
 ## 许可证

--- a/docs/FEISHU.md
+++ b/docs/FEISHU.md
@@ -1,0 +1,171 @@
+# Feishu (Lark) Setup Guide | 飞书配置指南
+
+**[English](#english) | [中文](#中文)**
+
+---
+
+## English
+
+MimiClaw supports [Feishu (Lark)](https://www.feishu.cn/) as a messaging channel. It uses **WebSocket long connection** — no public IP or webhook server required. Just configure your Feishu app credentials and MimiClaw connects directly to Feishu's event gateway.
+
+### 1. Create a Feishu App
+
+1. Go to [Feishu Open Platform](https://open.feishu.cn/app) and create a new app
+2. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**
+
+### 2. Enable Bot Capability
+
+1. Go to **Add Capabilities** → enable **Bot**
+2. Give your bot a name and avatar
+
+### 3. Add Permissions
+
+Go to **Permissions & Scopes** and add:
+
+| Permission | Description |
+|-----------|-------------|
+| `im:message` | Send messages |
+| `im:message.receive_v1` | Receive messages |
+
+### 4. Enable Events (Long Connection)
+
+1. Go to **Event Subscriptions**
+2. Set subscription mode to **Long Connection** (WebSocket)
+3. Add event: `im.message.receive_v1` (Receive messages)
+
+> **Important:** You must select **Long Connection** mode, not HTTP callback. This allows MimiClaw to receive events without a public IP.
+
+### 5. Publish the App
+
+1. Go to **App Release** → **Create Version**
+2. Fill in version info and submit for review
+3. For self-built apps in your own organization, approval is usually instant
+
+### 6. Configure MimiClaw
+
+**Option A: Build-time** — Edit `main/mimi_secrets.h`:
+
+```c
+#define MIMI_SECRET_FEISHU_APP_ID     "cli_xxxxxxxxxxxxxxxx"
+#define MIMI_SECRET_FEISHU_APP_SECRET "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+Then rebuild: `idf.py fullclean && idf.py build`
+
+**Option B: Runtime** — Via serial CLI (no recompile needed):
+
+```
+mimi> set_feishu_id cli_xxxxxxxxxxxxxxxx
+mimi> set_feishu_secret xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+mimi> restart
+```
+
+### 7. Verify
+
+After restart, you should see in the serial monitor:
+
+```
+I (xxxx) feishu: Feishu credentials loaded (app_id=cli_xxxx...)
+I (xxxx) feishu: Connecting to Feishu WebSocket...
+I (xxxx) feishu: WebSocket connected to Feishu
+```
+
+Send a message to your bot in Feishu — MimiClaw will reply!
+
+### Chat ID Format
+
+| Format | Type | Example |
+|--------|------|---------|
+| `ou_*` | User (1-on-1 chat) | `ou_abc123def456` |
+| `oc_*` | Group chat | `oc_xyz789ghi012` |
+
+### Troubleshooting
+
+- **"No Feishu credentials"** — Set App ID and App Secret via CLI or mimi_secrets.h
+- **WebSocket won't connect** — Check that event subscription mode is "Long Connection", not "HTTP callback"
+- **Bot doesn't respond in group** — Make sure the bot is added to the group and has `im:message` permission
+- **"Token API error"** — Verify App ID and App Secret are correct; check that the app is published
+
+---
+
+## 中文
+
+MimiClaw 支持[飞书](https://www.feishu.cn/)作为消息通道。使用 **WebSocket 长连接** — 不需要公网 IP 或 webhook 服务器。只需配置飞书应用凭证，MimiClaw 就会直接连接飞书的事件网关。
+
+### 1. 创建飞书应用
+
+1. 前往[飞书开放平台](https://open.feishu.cn/app)，创建一个新应用
+2. 在**凭证与基础信息**中，复制 **App ID** 和 **App Secret**
+
+### 2. 启用机器人能力
+
+1. 进入**添加应用能力** → 启用**机器人**
+2. 设置机器人名称和头像
+
+### 3. 添加权限
+
+进入**权限管理**，添加以下权限：
+
+| 权限 | 说明 |
+|-----|------|
+| `im:message` | 发送消息 |
+| `im:message.receive_v1` | 接收消息 |
+
+### 4. 启用事件订阅（长连接）
+
+1. 进入**事件订阅**
+2. 订阅方式选择**长连接**（WebSocket）
+3. 添加事件：`im.message.receive_v1`（接收消息）
+
+> **重要：** 必须选择**长连接**模式，不是 HTTP 回调。这样 MimiClaw 不需要公网 IP 就能接收事件。
+
+### 5. 发布应用
+
+1. 进入**版本管理与发布** → **创建版本**
+2. 填写版本信息并提交审核
+3. 自建应用在自己组织内通常会即时通过
+
+### 6. 配置 MimiClaw
+
+**方式 A：编译时** — 编辑 `main/mimi_secrets.h`：
+
+```c
+#define MIMI_SECRET_FEISHU_APP_ID     "cli_xxxxxxxxxxxxxxxx"
+#define MIMI_SECRET_FEISHU_APP_SECRET "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+然后重新编译：`idf.py fullclean && idf.py build`
+
+**方式 B：运行时** — 通过串口 CLI（无需重新编译）：
+
+```
+mimi> set_feishu_id cli_xxxxxxxxxxxxxxxx
+mimi> set_feishu_secret xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+mimi> restart
+```
+
+### 7. 验证
+
+重启后，串口监控应显示：
+
+```
+I (xxxx) feishu: Feishu credentials loaded (app_id=cli_xxxx...)
+I (xxxx) feishu: Connecting to Feishu WebSocket...
+I (xxxx) feishu: WebSocket connected to Feishu
+```
+
+在飞书给你的机器人发一条消息 — MimiClaw 会回复！
+
+### Chat ID 格式
+
+| 格式 | 类型 | 示例 |
+|------|------|------|
+| `ou_*` | 用户（单聊） | `ou_abc123def456` |
+| `oc_*` | 群聊 | `oc_xyz789ghi012` |
+
+### 常见问题
+
+- **"No Feishu credentials"** — 通过 CLI 或 mimi_secrets.h 设置 App ID 和 App Secret
+- **WebSocket 连接不上** — 检查事件订阅方式是否为「长连接」，而不是「HTTP 回调」
+- **群里机器人不回复** — 确保机器人已加入群组，并且有 `im:message` 权限
+- **"Token API error"** — 检查 App ID 和 App Secret 是否正确，应用是否已发布

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -24,6 +24,11 @@
 - **nanobot built-in tools** not yet ported: `read_file`, `write_file`, `edit_file`, `list_dir`, `message`
 - **Recommendation**: Reasonable tool subset for ESP32: `read_file`, `write_file`, `list_dir` (SPIFFS), `message`, `memory_write`
 
+### [ ] Cron Scheduled Task Service
+- **nanobot**: `cron/service.py` — full cron scheduler supporting at/every/cron expressions, persistent storage, timed agent triggers
+- **MimiClaw**: Not implemented
+- **Recommendation**: Use FreeRTOS timer for simplified version, support "every N minutes" only
+
 ### [ ] Subagent / Spawn Background Tasks
 - **nanobot**: `subagent.py` — SubagentManager spawns independent agent instances with isolated tool sets and system prompts, announces results back to main agent via system channel
 - **MimiClaw**: Not implemented
@@ -83,11 +88,6 @@
 ---
 
 ## P2 — Advanced Features
-
-### [ ] Cron Scheduled Task Service
-- **nanobot**: `cron/service.py` — full cron scheduler supporting at/every/cron expressions, persistent storage, timed agent triggers
-- **MimiClaw**: Not implemented
-- **Recommendation**: Use FreeRTOS timer for simplified version, support "every N minutes" only
 
 ### [ ] Heartbeat Service
 - **nanobot**: `heartbeat/service.py` — reads HEARTBEAT.md every 30 minutes, triggers agent if tasks are found
@@ -158,12 +158,12 @@
 ```
 1. [done] Tool Use Loop + Tool Registry + web_search
 2. Memory Write via Tool Use         <- makes the agent actually remember
-3. Built-in Tools (read_file, write_file, message)
-4. Telegram Allowlist (allow_from)   <- security essential
-5. Bootstrap File Completion (AGENTS.md, TOOLS.md)
-6. Subagent (simplified)
-7. Telegram Markdown -> HTML
-8. Media Handling
-9. Cron / Heartbeat
-10. Other enhancements
+3. Cron Scheduled Tasks              <- autonomous timed actions
+4. Built-in Tools (read_file, write_file, message)
+5. Telegram Allowlist (allow_from)   <- security essential
+6. Bootstrap File Completion (AGENTS.md, TOOLS.md)
+7. Subagent (simplified)
+8. Telegram Markdown -> HTML
+9. Media Handling
+10. Heartbeat / Other enhancements
 ```

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -17,9 +17,11 @@ idf_component_register(
         "tools/tool_web_search.c"
         "tools/tool_get_time.c"
         "tools/tool_files.c"
+        "feishu/feishu_bot.c"
     INCLUDE_DIRS
         "."
     REQUIRES
         nvs_flash esp_wifi esp_netif esp_http_client esp_http_server
         esp_https_ota esp_event json spiffs console vfs app_update esp-tls
+        esp_websocket_client
 )

--- a/main/bus/message_bus.h
+++ b/main/bus/message_bus.h
@@ -8,6 +8,7 @@
 #define MIMI_CHAN_TELEGRAM   "telegram"
 #define MIMI_CHAN_WEBSOCKET  "websocket"
 #define MIMI_CHAN_CLI        "cli"
+#define MIMI_CHAN_FEISHU     "feishu"
 
 /* Message types on the bus */
 typedef struct {

--- a/main/feishu/feishu_bot.c
+++ b/main/feishu/feishu_bot.c
@@ -1,0 +1,839 @@
+#include "feishu_bot.h"
+#include "mimi_config.h"
+#include "bus/message_bus.h"
+#include "proxy/http_proxy.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_http_client.h"
+#include "esp_crt_bundle.h"
+#include "esp_websocket_client.h"
+#include "nvs.h"
+#include "cJSON.h"
+
+static const char *TAG = "feishu";
+
+/* ── Static state ──────────────────────────────────────────────── */
+
+static char s_app_id[64]      = MIMI_SECRET_FEISHU_APP_ID;
+static char s_app_secret[64]  = MIMI_SECRET_FEISHU_APP_SECRET;
+static char s_tenant_token[256] = {0};
+static time_t s_token_expire = 0;
+static int s_service_id = 0;
+static esp_websocket_client_handle_t s_ws_client = NULL;
+
+/* Dedup ring buffer */
+#define DEDUP_SIZE 64
+static char s_dedup[DEDUP_SIZE][32];
+static int  s_dedup_idx = 0;
+
+/* ── HTTP response accumulator ────────────────────────────────── */
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+} http_resp_t;
+
+static esp_err_t http_event_handler(esp_http_client_event_t *evt)
+{
+    http_resp_t *resp = (http_resp_t *)evt->user_data;
+    if (evt->event_id == HTTP_EVENT_ON_DATA && resp) {
+        if (resp->len + evt->data_len < resp->cap) {
+            memcpy(resp->buf + resp->len, evt->data, evt->data_len);
+            resp->len += evt->data_len;
+            resp->buf[resp->len] = '\0';
+        }
+    }
+    return ESP_OK;
+}
+
+/* ── Minimal Protobuf codec for Frame/Header ──────────────────── */
+
+/*
+ * Feishu WebSocket uses protobuf-encoded frames:
+ *
+ * message Header { required string key=1; required string value=2; }
+ * message Frame {
+ *   required uint64 SeqID=1; required uint64 LogID=2;
+ *   required int32 service=3; required int32 method=4;
+ *   repeated Header headers=5;
+ *   optional string payload_encoding=6; optional string payload_type=7;
+ *   optional bytes payload=8; optional string LogIDNew=9;
+ * }
+ *
+ * method: 0=CONTROL, 1=DATA
+ * header "type": "event"|"ping"|"pong"
+ */
+
+#define PB_VARINT   0
+#define PB_LENDELIM 2
+
+#define MAX_HEADERS 16
+
+typedef struct {
+    char key[32];
+    char value[64];
+} pb_header_t;
+
+typedef struct {
+    uint64_t seq_id;
+    uint64_t log_id;
+    int32_t  service;
+    int32_t  method;     /* 0=CONTROL, 1=DATA */
+    pb_header_t headers[MAX_HEADERS];
+    int      header_count;
+    uint8_t *payload;
+    size_t   payload_len;
+} pb_frame_t;
+
+/* Read a varint from buf, advance *pos. Returns the value. */
+static uint64_t pb_read_varint(const uint8_t *buf, size_t len, size_t *pos)
+{
+    uint64_t val = 0;
+    int shift = 0;
+    while (*pos < len) {
+        uint8_t b = buf[(*pos)++];
+        val |= (uint64_t)(b & 0x7F) << shift;
+        if (!(b & 0x80)) break;
+        shift += 7;
+    }
+    return val;
+}
+
+/* Write a varint to buf, return bytes written */
+static size_t pb_write_varint(uint8_t *buf, uint64_t val)
+{
+    size_t n = 0;
+    do {
+        uint8_t b = val & 0x7F;
+        val >>= 7;
+        if (val) b |= 0x80;
+        buf[n++] = b;
+    } while (val);
+    return n;
+}
+
+/* Write a field tag */
+static size_t pb_write_tag(uint8_t *buf, int field, int wire_type)
+{
+    return pb_write_varint(buf, ((uint64_t)field << 3) | wire_type);
+}
+
+/* Parse a Header sub-message from bytes */
+static void pb_parse_header(const uint8_t *buf, size_t len, pb_header_t *hdr)
+{
+    size_t pos = 0;
+    memset(hdr, 0, sizeof(*hdr));
+    while (pos < len) {
+        uint64_t tag = pb_read_varint(buf, len, &pos);
+        int field = (int)(tag >> 3);
+        int wtype = (int)(tag & 7);
+        if (wtype == PB_LENDELIM) {
+            size_t slen = (size_t)pb_read_varint(buf, len, &pos);
+            if (pos + slen > len) break;
+            if (field == 1) { /* key */
+                size_t copy = slen < sizeof(hdr->key) - 1 ? slen : sizeof(hdr->key) - 1;
+                memcpy(hdr->key, buf + pos, copy);
+                hdr->key[copy] = '\0';
+            } else if (field == 2) { /* value */
+                size_t copy = slen < sizeof(hdr->value) - 1 ? slen : sizeof(hdr->value) - 1;
+                memcpy(hdr->value, buf + pos, copy);
+                hdr->value[copy] = '\0';
+            }
+            pos += slen;
+        } else if (wtype == PB_VARINT) {
+            pb_read_varint(buf, len, &pos);
+        } else {
+            break;
+        }
+    }
+}
+
+/* Parse a Frame from binary protobuf */
+static bool pb_parse_frame(const uint8_t *buf, size_t len, pb_frame_t *frame)
+{
+    memset(frame, 0, sizeof(*frame));
+    size_t pos = 0;
+    while (pos < len) {
+        uint64_t tag = pb_read_varint(buf, len, &pos);
+        int field = (int)(tag >> 3);
+        int wtype = (int)(tag & 7);
+        if (wtype == PB_VARINT) {
+            uint64_t val = pb_read_varint(buf, len, &pos);
+            switch (field) {
+                case 1: frame->seq_id = val; break;
+                case 2: frame->log_id = val; break;
+                case 3: frame->service = (int32_t)val; break;
+                case 4: frame->method  = (int32_t)val; break;
+                default: break;
+            }
+        } else if (wtype == PB_LENDELIM) {
+            size_t slen = (size_t)pb_read_varint(buf, len, &pos);
+            if (pos + slen > len) return false;
+            if (field == 5 && frame->header_count < MAX_HEADERS) {
+                pb_parse_header(buf + pos, slen, &frame->headers[frame->header_count++]);
+            } else if (field == 8) {
+                frame->payload = (uint8_t *)(buf + pos);
+                frame->payload_len = slen;
+            }
+            /* skip fields 6,7,9 */
+            pos += slen;
+        } else {
+            break;
+        }
+    }
+    return true;
+}
+
+/* Encode a ping frame. Returns bytes written to buf. */
+static size_t pb_encode_ping(uint8_t *buf, size_t cap, int service_id)
+{
+    size_t pos = 0;
+
+    /* SeqID = 0 (field 1, varint) */
+    pos += pb_write_tag(buf + pos, 1, PB_VARINT);
+    pos += pb_write_varint(buf + pos, 0);
+
+    /* LogID = 0 (field 2, varint) */
+    pos += pb_write_tag(buf + pos, 2, PB_VARINT);
+    pos += pb_write_varint(buf + pos, 0);
+
+    /* service (field 3, varint) */
+    pos += pb_write_tag(buf + pos, 3, PB_VARINT);
+    pos += pb_write_varint(buf + pos, (uint64_t)service_id);
+
+    /* method = 0 (CONTROL) (field 4, varint) */
+    pos += pb_write_tag(buf + pos, 4, PB_VARINT);
+    pos += pb_write_varint(buf + pos, 0);
+
+    /* header: {key:"type", value:"ping"} (field 5, lendelim) */
+    /* Build sub-message first */
+    uint8_t hdr_buf[64];
+    size_t hpos = 0;
+    hpos += pb_write_tag(hdr_buf + hpos, 1, PB_LENDELIM);
+    hpos += pb_write_varint(hdr_buf + hpos, 4); /* "type" length */
+    memcpy(hdr_buf + hpos, "type", 4); hpos += 4;
+    hpos += pb_write_tag(hdr_buf + hpos, 2, PB_LENDELIM);
+    hpos += pb_write_varint(hdr_buf + hpos, 4); /* "ping" length */
+    memcpy(hdr_buf + hpos, "ping", 4); hpos += 4;
+
+    pos += pb_write_tag(buf + pos, 5, PB_LENDELIM);
+    pos += pb_write_varint(buf + pos, hpos);
+    memcpy(buf + pos, hdr_buf, hpos);
+    pos += hpos;
+
+    return pos;
+}
+
+/* Get header value by key from parsed frame */
+static const char *pb_get_header(const pb_frame_t *frame, const char *key)
+{
+    for (int i = 0; i < frame->header_count; i++) {
+        if (strcmp(frame->headers[i].key, key) == 0)
+            return frame->headers[i].value;
+    }
+    return NULL;
+}
+
+/* ── Dedup ────────────────────────────────────────────────────── */
+
+static bool dedup_check_and_add(const char *msg_id)
+{
+    for (int i = 0; i < DEDUP_SIZE; i++) {
+        if (strcmp(s_dedup[i], msg_id) == 0) return true; /* already seen */
+    }
+    strncpy(s_dedup[s_dedup_idx], msg_id, 31);
+    s_dedup[s_dedup_idx][31] = '\0';
+    s_dedup_idx = (s_dedup_idx + 1) % DEDUP_SIZE;
+    return false;
+}
+
+/* ── Tenant access token ──────────────────────────────────────── */
+
+static esp_err_t feishu_refresh_token(void)
+{
+    cJSON *body = cJSON_CreateObject();
+    cJSON_AddStringToObject(body, "app_id", s_app_id);
+    cJSON_AddStringToObject(body, "app_secret", s_app_secret);
+    char *post_data = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!post_data) return ESP_ERR_NO_MEM;
+
+    http_resp_t resp = { .buf = calloc(1, 4096), .len = 0, .cap = 4096 };
+    if (!resp.buf) { free(post_data); return ESP_ERR_NO_MEM; }
+
+    esp_http_client_config_t config = {
+        .url = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+        .event_handler = http_event_handler,
+        .user_data = &resp,
+        .timeout_ms = 10000,
+        .buffer_size = 2048,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (!client) { free(post_data); free(resp.buf); return ESP_FAIL; }
+
+    esp_http_client_set_method(client, HTTP_METHOD_POST);
+    esp_http_client_set_header(client, "Content-Type", "application/json; charset=utf-8");
+    esp_http_client_set_post_field(client, post_data, strlen(post_data));
+
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    free(post_data);
+
+    if (err != ESP_OK || status != 200) {
+        ESP_LOGE(TAG, "Token request failed: err=%s status=%d", esp_err_to_name(err), status);
+        free(resp.buf);
+        return ESP_FAIL;
+    }
+
+    cJSON *root = cJSON_Parse(resp.buf);
+    free(resp.buf);
+    if (!root) return ESP_FAIL;
+
+    cJSON *code = cJSON_GetObjectItem(root, "code");
+    if (!code || code->valueint != 0) {
+        cJSON *msg = cJSON_GetObjectItem(root, "msg");
+        ESP_LOGE(TAG, "Token API error: %s", msg ? msg->valuestring : "unknown");
+        cJSON_Delete(root);
+        return ESP_FAIL;
+    }
+
+    cJSON *token = cJSON_GetObjectItem(root, "tenant_access_token");
+    cJSON *expire = cJSON_GetObjectItem(root, "expire");
+    if (!token || !cJSON_IsString(token)) {
+        cJSON_Delete(root);
+        return ESP_FAIL;
+    }
+
+    strncpy(s_tenant_token, token->valuestring, sizeof(s_tenant_token) - 1);
+    s_token_expire = time(NULL) + (expire ? expire->valueint : 7200) - 300; /* refresh 5 min early */
+
+    ESP_LOGI(TAG, "Tenant token acquired (expires in %ds)", expire ? expire->valueint : 7200);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+static esp_err_t feishu_ensure_token(void)
+{
+    if (s_tenant_token[0] && time(NULL) < s_token_expire) return ESP_OK;
+    return feishu_refresh_token();
+}
+
+/* ── Get WebSocket endpoint ───────────────────────────────────── */
+
+static char *feishu_get_ws_url(void)
+{
+    if (feishu_ensure_token() != ESP_OK) return NULL;
+
+    cJSON *body = cJSON_CreateObject();
+    cJSON_AddStringToObject(body, "AppID", s_app_id);
+    cJSON_AddStringToObject(body, "AppSecret", s_app_secret);
+    char *post_data = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!post_data) return NULL;
+
+    http_resp_t resp = { .buf = calloc(1, 4096), .len = 0, .cap = 4096 };
+    if (!resp.buf) { free(post_data); return NULL; }
+
+    esp_http_client_config_t config = {
+        .url = "https://open.feishu.cn/callback/ws/endpoint",
+        .event_handler = http_event_handler,
+        .user_data = &resp,
+        .timeout_ms = 10000,
+        .buffer_size = 2048,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (!client) { free(post_data); free(resp.buf); return NULL; }
+
+    esp_http_client_set_method(client, HTTP_METHOD_POST);
+    esp_http_client_set_header(client, "Content-Type", "application/json; charset=utf-8");
+    esp_http_client_set_post_field(client, post_data, strlen(post_data));
+
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    free(post_data);
+
+    if (err != ESP_OK || status != 200) {
+        ESP_LOGE(TAG, "WS endpoint request failed: err=%s status=%d", esp_err_to_name(err), status);
+        free(resp.buf);
+        return NULL;
+    }
+
+    cJSON *root = cJSON_Parse(resp.buf);
+    free(resp.buf);
+    if (!root) return NULL;
+
+    cJSON *code = cJSON_GetObjectItem(root, "code");
+    if (!code || code->valueint != 0) {
+        cJSON *msg = cJSON_GetObjectItem(root, "msg");
+        ESP_LOGE(TAG, "WS endpoint error: %s", msg ? msg->valuestring : "unknown");
+        cJSON_Delete(root);
+        return NULL;
+    }
+
+    cJSON *data = cJSON_GetObjectItem(root, "data");
+    cJSON *url = data ? cJSON_GetObjectItem(data, "URL") : NULL;
+    if (!url || !cJSON_IsString(url)) {
+        cJSON_Delete(root);
+        return NULL;
+    }
+
+    /* Extract service_id from URL query param */
+    const char *sid = strstr(url->valuestring, "service_id=");
+    if (sid) s_service_id = atoi(sid + 11);
+
+    /* Parse ClientConfig if present */
+    cJSON *cc = data ? cJSON_GetObjectItem(data, "ClientConfig") : NULL;
+    if (cc) {
+        cJSON *pi = cJSON_GetObjectItem(cc, "PingInterval");
+        if (pi && cJSON_IsNumber(pi)) {
+            ESP_LOGI(TAG, "PingInterval: %d", pi->valueint);
+        }
+    }
+
+    char *ws_url = strdup(url->valuestring);
+    cJSON_Delete(root);
+
+    ESP_LOGI(TAG, "WebSocket URL acquired");
+    return ws_url;
+}
+
+/* ── Handle incoming event ────────────────────────────────────── */
+
+static void handle_feishu_event(const uint8_t *payload, size_t payload_len)
+{
+    /* payload is the Feishu event JSON, e.g.:
+     * {"schema":"2.0","header":{"event_type":"im.message.receive_v1",...},
+     *  "event":{"message":{"message_type":"text","content":"{\"text\":\"hello\"}",
+     *           "chat_id":"oc_xxx","message_id":"om_xxx"},
+     *           "sender":{"sender_id":{"open_id":"ou_xxx"},"sender_type":"user"}}}
+     */
+    cJSON *root = cJSON_ParseWithLength((const char *)payload, payload_len);
+    if (!root) {
+        ESP_LOGW(TAG, "Failed to parse event JSON");
+        return;
+    }
+
+    /* Check event type */
+    cJSON *header = cJSON_GetObjectItem(root, "header");
+    cJSON *event_type = header ? cJSON_GetObjectItem(header, "event_type") : NULL;
+    if (!event_type || !cJSON_IsString(event_type) ||
+        strcmp(event_type->valuestring, "im.message.receive_v1") != 0) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    cJSON *event = cJSON_GetObjectItem(root, "event");
+    if (!event) { cJSON_Delete(root); return; }
+
+    /* Get sender info */
+    cJSON *sender = cJSON_GetObjectItem(event, "sender");
+    cJSON *sender_type = sender ? cJSON_GetObjectItem(sender, "sender_type") : NULL;
+    if (sender_type && cJSON_IsString(sender_type) &&
+        strcmp(sender_type->valuestring, "bot") == 0) {
+        cJSON_Delete(root);
+        return; /* skip bot messages */
+    }
+
+    cJSON *sender_id_obj = sender ? cJSON_GetObjectItem(sender, "sender_id") : NULL;
+    cJSON *open_id = sender_id_obj ? cJSON_GetObjectItem(sender_id_obj, "open_id") : NULL;
+
+    /* Get message info */
+    cJSON *message = cJSON_GetObjectItem(event, "message");
+    if (!message) { cJSON_Delete(root); return; }
+
+    cJSON *msg_id = cJSON_GetObjectItem(message, "message_id");
+    cJSON *msg_type = cJSON_GetObjectItem(message, "message_type");
+    cJSON *chat_id = cJSON_GetObjectItem(message, "chat_id");
+    cJSON *chat_type = cJSON_GetObjectItem(message, "chat_type");
+    cJSON *content_str = cJSON_GetObjectItem(message, "content");
+
+    if (!msg_id || !cJSON_IsString(msg_id)) { cJSON_Delete(root); return; }
+
+    /* Dedup */
+    if (dedup_check_and_add(msg_id->valuestring)) {
+        cJSON_Delete(root);
+        return;
+    }
+
+    /* Parse text content */
+    char text[1024] = {0};
+    if (msg_type && cJSON_IsString(msg_type) &&
+        strcmp(msg_type->valuestring, "text") == 0 &&
+        content_str && cJSON_IsString(content_str)) {
+        cJSON *content = cJSON_Parse(content_str->valuestring);
+        if (content) {
+            cJSON *t = cJSON_GetObjectItem(content, "text");
+            if (t && cJSON_IsString(t)) {
+                strncpy(text, t->valuestring, sizeof(text) - 1);
+            }
+            cJSON_Delete(content);
+        }
+    } else {
+        /* Non-text message */
+        snprintf(text, sizeof(text), "[%s]",
+                 (msg_type && cJSON_IsString(msg_type)) ? msg_type->valuestring : "unknown");
+    }
+
+    if (text[0] == '\0') { cJSON_Delete(root); return; }
+
+    /* Determine reply target: group → chat_id, p2p → sender open_id */
+    const char *reply_to = NULL;
+    if (chat_type && cJSON_IsString(chat_type) &&
+        strcmp(chat_type->valuestring, "group") == 0 &&
+        chat_id && cJSON_IsString(chat_id)) {
+        reply_to = chat_id->valuestring;
+    } else if (open_id && cJSON_IsString(open_id)) {
+        reply_to = open_id->valuestring;
+    }
+
+    if (!reply_to) { cJSON_Delete(root); return; }
+
+    ESP_LOGI(TAG, "Message from %s: %.40s...", reply_to, text);
+
+    /* Push to inbound bus */
+    mimi_msg_t msg = {0};
+    strncpy(msg.channel, MIMI_CHAN_FEISHU, sizeof(msg.channel) - 1);
+    strncpy(msg.chat_id, reply_to, sizeof(msg.chat_id) - 1);
+    msg.content = strdup(text);
+    if (msg.content) {
+        message_bus_push_inbound(&msg);
+    }
+
+    cJSON_Delete(root);
+}
+
+/* ── WebSocket event handler ──────────────────────────────────── */
+
+static void feishu_ws_event_handler(void *arg, esp_event_base_t base,
+                                     int32_t event_id, void *event_data)
+{
+    esp_websocket_event_data_t *data = (esp_websocket_event_data_t *)event_data;
+
+    switch (event_id) {
+    case WEBSOCKET_EVENT_CONNECTED:
+        ESP_LOGI(TAG, "WebSocket connected to Feishu");
+        break;
+
+    case WEBSOCKET_EVENT_DISCONNECTED:
+        ESP_LOGW(TAG, "WebSocket disconnected from Feishu");
+        break;
+
+    case WEBSOCKET_EVENT_DATA:
+        if (data->op_code == 0x02 && data->data_len > 0) {
+            /* Binary frame = protobuf Frame */
+            pb_frame_t frame;
+            if (!pb_parse_frame((const uint8_t *)data->data_ptr, data->data_len, &frame))
+                break;
+
+            const char *type = pb_get_header(&frame, "type");
+            if (!type) break;
+
+            if (frame.method == 0) {
+                /* CONTROL frame */
+                if (strcmp(type, "pong") == 0) {
+                    ESP_LOGD(TAG, "Received pong");
+                }
+            } else if (frame.method == 1) {
+                /* DATA frame */
+                if (strcmp(type, "event") == 0 && frame.payload && frame.payload_len > 0) {
+                    handle_feishu_event(frame.payload, frame.payload_len);
+
+                    /* Send ack response: rewrite payload in original frame */
+                    const char *resp_json = "{\"code\":200}";
+                    uint8_t resp_buf[512];
+                    size_t rpos = 0;
+
+                    /* Rebuild frame with response payload */
+                    rpos += pb_write_tag(resp_buf + rpos, 1, PB_VARINT);
+                    rpos += pb_write_varint(resp_buf + rpos, frame.seq_id);
+                    rpos += pb_write_tag(resp_buf + rpos, 2, PB_VARINT);
+                    rpos += pb_write_varint(resp_buf + rpos, frame.log_id);
+                    rpos += pb_write_tag(resp_buf + rpos, 3, PB_VARINT);
+                    rpos += pb_write_varint(resp_buf + rpos, (uint64_t)frame.service);
+                    rpos += pb_write_tag(resp_buf + rpos, 4, PB_VARINT);
+                    rpos += pb_write_varint(resp_buf + rpos, (uint64_t)frame.method);
+
+                    /* Copy original headers + add biz_rt */
+                    for (int i = 0; i < frame.header_count; i++) {
+                        uint8_t hdr_buf[128];
+                        size_t hlen = 0;
+                        hlen += pb_write_tag(hdr_buf + hlen, 1, PB_LENDELIM);
+                        size_t klen = strlen(frame.headers[i].key);
+                        hlen += pb_write_varint(hdr_buf + hlen, klen);
+                        memcpy(hdr_buf + hlen, frame.headers[i].key, klen); hlen += klen;
+                        hlen += pb_write_tag(hdr_buf + hlen, 2, PB_LENDELIM);
+                        size_t vlen = strlen(frame.headers[i].value);
+                        hlen += pb_write_varint(hdr_buf + hlen, vlen);
+                        memcpy(hdr_buf + hlen, frame.headers[i].value, vlen); hlen += vlen;
+
+                        rpos += pb_write_tag(resp_buf + rpos, 5, PB_LENDELIM);
+                        rpos += pb_write_varint(resp_buf + rpos, hlen);
+                        memcpy(resp_buf + rpos, hdr_buf, hlen); rpos += hlen;
+                    }
+
+                    /* payload = response JSON (field 8) */
+                    size_t plen = strlen(resp_json);
+                    rpos += pb_write_tag(resp_buf + rpos, 8, PB_LENDELIM);
+                    rpos += pb_write_varint(resp_buf + rpos, plen);
+                    memcpy(resp_buf + rpos, resp_json, plen); rpos += plen;
+
+                    if (s_ws_client) {
+                        esp_websocket_client_send_bin(s_ws_client, (const char *)resp_buf, rpos, pdMS_TO_TICKS(5000));
+                    }
+                }
+            }
+        }
+        break;
+
+    case WEBSOCKET_EVENT_ERROR:
+        ESP_LOGE(TAG, "WebSocket error");
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* ── Feishu task ──────────────────────────────────────────────── */
+
+static void feishu_task(void *arg)
+{
+    ESP_LOGI(TAG, "Feishu task started");
+
+    while (1) {
+        if (s_app_id[0] == '\0' || s_app_secret[0] == '\0') {
+            ESP_LOGW(TAG, "No Feishu credentials, waiting...");
+            vTaskDelay(pdMS_TO_TICKS(10000));
+            continue;
+        }
+
+        /* Get WebSocket URL */
+        char *ws_url = feishu_get_ws_url();
+        if (!ws_url) {
+            ESP_LOGE(TAG, "Failed to get WS URL, retrying in 30s...");
+            vTaskDelay(pdMS_TO_TICKS(30000));
+            continue;
+        }
+
+        ESP_LOGI(TAG, "Connecting to Feishu WebSocket...");
+
+        esp_websocket_client_config_t ws_config = {
+            .uri = ws_url,
+            .buffer_size = 4096,
+            .task_stack = 6 * 1024,
+            .pingpong_timeout_sec = 0, /* we handle ping ourselves */
+        };
+
+        s_ws_client = esp_websocket_client_init(&ws_config);
+        if (!s_ws_client) {
+            ESP_LOGE(TAG, "Failed to init WS client");
+            free(ws_url);
+            vTaskDelay(pdMS_TO_TICKS(30000));
+            continue;
+        }
+
+        esp_websocket_register_events(s_ws_client, WEBSOCKET_EVENT_ANY,
+                                       feishu_ws_event_handler, NULL);
+        esp_err_t err = esp_websocket_client_start(s_ws_client);
+        free(ws_url);
+
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to start WS client");
+            esp_websocket_client_destroy(s_ws_client);
+            s_ws_client = NULL;
+            vTaskDelay(pdMS_TO_TICKS(30000));
+            continue;
+        }
+
+        /* Ping loop — send ping every 120s, check connection */
+        while (esp_websocket_client_is_connected(s_ws_client)) {
+            /* Send ping */
+            uint8_t ping_buf[64];
+            size_t ping_len = pb_encode_ping(ping_buf, sizeof(ping_buf), s_service_id);
+            esp_websocket_client_send_bin(s_ws_client, (const char *)ping_buf, ping_len, pdMS_TO_TICKS(5000));
+            ESP_LOGD(TAG, "Ping sent");
+
+            /* Wait 120s, checking connection periodically */
+            for (int i = 0; i < 120 && esp_websocket_client_is_connected(s_ws_client); i++) {
+                vTaskDelay(pdMS_TO_TICKS(1000));
+            }
+        }
+
+        /* Disconnected — cleanup and reconnect */
+        ESP_LOGW(TAG, "Feishu disconnected, reconnecting in 10s...");
+        esp_websocket_client_stop(s_ws_client);
+        esp_websocket_client_destroy(s_ws_client);
+        s_ws_client = NULL;
+        vTaskDelay(pdMS_TO_TICKS(10000));
+    }
+}
+
+/* ── Send message via REST API ────────────────────────────────── */
+
+esp_err_t feishu_send_message(const char *chat_id, const char *text)
+{
+    if (feishu_ensure_token() != ESP_OK) {
+        ESP_LOGE(TAG, "Cannot send: no valid token");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Determine receive_id_type: oc_* = chat_id, ou_* = open_id */
+    const char *id_type = "open_id";
+    if (strncmp(chat_id, "oc_", 3) == 0) {
+        id_type = "chat_id";
+    }
+
+    /* Build URL with query param */
+    char url[256];
+    snprintf(url, sizeof(url),
+             "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=%s", id_type);
+
+    /* Build message body */
+    cJSON *content = cJSON_CreateObject();
+    cJSON_AddStringToObject(content, "text", text);
+    char *content_str = cJSON_PrintUnformatted(content);
+    cJSON_Delete(content);
+
+    cJSON *body = cJSON_CreateObject();
+    cJSON_AddStringToObject(body, "receive_id", chat_id);
+    cJSON_AddStringToObject(body, "msg_type", "text");
+    cJSON_AddStringToObject(body, "content", content_str);
+    free(content_str);
+
+    char *post_data = cJSON_PrintUnformatted(body);
+    cJSON_Delete(body);
+    if (!post_data) return ESP_ERR_NO_MEM;
+
+    http_resp_t resp = { .buf = calloc(1, 2048), .len = 0, .cap = 2048 };
+    if (!resp.buf) { free(post_data); return ESP_ERR_NO_MEM; }
+
+    esp_http_client_config_t config = {
+        .url = url,
+        .event_handler = http_event_handler,
+        .user_data = &resp,
+        .timeout_ms = 10000,
+        .buffer_size = 2048,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (!client) { free(post_data); free(resp.buf); return ESP_FAIL; }
+
+    char auth[300];
+    snprintf(auth, sizeof(auth), "Bearer %s", s_tenant_token);
+    esp_http_client_set_method(client, HTTP_METHOD_POST);
+    esp_http_client_set_header(client, "Content-Type", "application/json; charset=utf-8");
+    esp_http_client_set_header(client, "Authorization", auth);
+    esp_http_client_set_post_field(client, post_data, strlen(post_data));
+
+    esp_err_t err = esp_http_client_perform(client);
+    int status = esp_http_client_get_status_code(client);
+    esp_http_client_cleanup(client);
+    free(post_data);
+
+    if (err != ESP_OK || status != 200) {
+        ESP_LOGE(TAG, "Send message failed: err=%s status=%d resp=%s",
+                 esp_err_to_name(err), status, resp.buf);
+        free(resp.buf);
+        return ESP_FAIL;
+    }
+
+    /* Check API response */
+    cJSON *root = cJSON_Parse(resp.buf);
+    free(resp.buf);
+    if (root) {
+        cJSON *code = cJSON_GetObjectItem(root, "code");
+        if (code && code->valueint != 0) {
+            cJSON *msg = cJSON_GetObjectItem(root, "msg");
+            ESP_LOGE(TAG, "Send API error: code=%d msg=%s",
+                     code->valueint, msg ? msg->valuestring : "");
+        } else {
+            ESP_LOGD(TAG, "Message sent to %s", chat_id);
+        }
+        cJSON_Delete(root);
+    }
+
+    return ESP_OK;
+}
+
+/* ── Public API ───────────────────────────────────────────────── */
+
+esp_err_t feishu_bot_init(void)
+{
+    /* NVS overrides take highest priority */
+    nvs_handle_t nvs;
+    if (nvs_open(MIMI_NVS_FEISHU, NVS_READONLY, &nvs) == ESP_OK) {
+        char tmp[64] = {0};
+        size_t len = sizeof(tmp);
+        if (nvs_get_str(nvs, MIMI_NVS_KEY_FEISHU_APP_ID, tmp, &len) == ESP_OK && tmp[0]) {
+            strncpy(s_app_id, tmp, sizeof(s_app_id) - 1);
+        }
+        len = sizeof(tmp);
+        memset(tmp, 0, sizeof(tmp));
+        if (nvs_get_str(nvs, MIMI_NVS_KEY_FEISHU_SECRET, tmp, &len) == ESP_OK && tmp[0]) {
+            strncpy(s_app_secret, tmp, sizeof(s_app_secret) - 1);
+        }
+        nvs_close(nvs);
+    }
+
+    if (s_app_id[0] && s_app_secret[0]) {
+        ESP_LOGI(TAG, "Feishu credentials loaded (app_id=%.8s...)", s_app_id);
+    } else {
+        ESP_LOGW(TAG, "No Feishu credentials. Use CLI: set_feishu_id + set_feishu_secret");
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t feishu_bot_start(void)
+{
+    if (s_app_id[0] == '\0' || s_app_secret[0] == '\0') {
+        ESP_LOGW(TAG, "Feishu not started: no credentials configured");
+        return ESP_OK; /* not an error, just skip */
+    }
+
+    BaseType_t ret = xTaskCreatePinnedToCore(
+        feishu_task, "feishu",
+        MIMI_FEISHU_STACK, NULL,
+        MIMI_FEISHU_PRIO, NULL, MIMI_FEISHU_CORE);
+
+    return (ret == pdPASS) ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t feishu_set_app_id(const char *app_id)
+{
+    nvs_handle_t nvs;
+    ESP_ERROR_CHECK(nvs_open(MIMI_NVS_FEISHU, NVS_READWRITE, &nvs));
+    ESP_ERROR_CHECK(nvs_set_str(nvs, MIMI_NVS_KEY_FEISHU_APP_ID, app_id));
+    ESP_ERROR_CHECK(nvs_commit(nvs));
+    nvs_close(nvs);
+
+    strncpy(s_app_id, app_id, sizeof(s_app_id) - 1);
+    ESP_LOGI(TAG, "Feishu App ID saved");
+    return ESP_OK;
+}
+
+esp_err_t feishu_set_app_secret(const char *app_secret)
+{
+    nvs_handle_t nvs;
+    ESP_ERROR_CHECK(nvs_open(MIMI_NVS_FEISHU, NVS_READWRITE, &nvs));
+    ESP_ERROR_CHECK(nvs_set_str(nvs, MIMI_NVS_KEY_FEISHU_SECRET, app_secret));
+    ESP_ERROR_CHECK(nvs_commit(nvs));
+    nvs_close(nvs);
+
+    strncpy(s_app_secret, app_secret, sizeof(s_app_secret) - 1);
+    ESP_LOGI(TAG, "Feishu App Secret saved");
+    return ESP_OK;
+}

--- a/main/feishu/feishu_bot.h
+++ b/main/feishu/feishu_bot.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esp_err.h"
+
+/**
+ * Initialize Feishu bot (load credentials from NVS/secrets).
+ */
+esp_err_t feishu_bot_init(void);
+
+/**
+ * Start Feishu bot (create WebSocket long connection task on Core 0).
+ */
+esp_err_t feishu_bot_start(void);
+
+/**
+ * Send a text message to a Feishu user or group.
+ * @param chat_id  Feishu open_id (ou_*) or chat_id (oc_*)
+ * @param text     Message content
+ */
+esp_err_t feishu_send_message(const char *chat_id, const char *text);
+
+/**
+ * Save Feishu App ID to NVS.
+ */
+esp_err_t feishu_set_app_id(const char *app_id);
+
+/**
+ * Save Feishu App Secret to NVS.
+ */
+esp_err_t feishu_set_app_secret(const char *app_secret);

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/esp_websocket_client: "^1.0.0"

--- a/main/mimi.c
+++ b/main/mimi.c
@@ -21,6 +21,7 @@
 #include "cli/serial_cli.h"
 #include "proxy/http_proxy.h"
 #include "tools/tool_registry.h"
+#include "feishu/feishu_bot.h"
 
 static const char *TAG = "mimi";
 
@@ -72,6 +73,8 @@ static void outbound_dispatch_task(void *arg)
             telegram_send_message(msg.chat_id, msg.content);
         } else if (strcmp(msg.channel, MIMI_CHAN_WEBSOCKET) == 0) {
             ws_server_send(msg.chat_id, msg.content);
+        } else if (strcmp(msg.channel, MIMI_CHAN_FEISHU) == 0) {
+            feishu_send_message(msg.chat_id, msg.content);
         } else {
             ESP_LOGW(TAG, "Unknown channel: %s", msg.channel);
         }
@@ -107,6 +110,7 @@ void app_main(void)
     ESP_ERROR_CHECK(wifi_manager_init());
     ESP_ERROR_CHECK(http_proxy_init());
     ESP_ERROR_CHECK(telegram_bot_init());
+    ESP_ERROR_CHECK(feishu_bot_init());
     ESP_ERROR_CHECK(llm_proxy_init());
     ESP_ERROR_CHECK(tool_registry_init());
     ESP_ERROR_CHECK(agent_loop_init());
@@ -123,6 +127,7 @@ void app_main(void)
 
             /* Start network-dependent services */
             ESP_ERROR_CHECK(telegram_bot_start());
+            feishu_bot_start();
             ESP_ERROR_CHECK(agent_loop_start());
             ESP_ERROR_CHECK(ws_server_start());
 

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -31,6 +31,12 @@
 #ifndef MIMI_SECRET_SEARCH_KEY
 #define MIMI_SECRET_SEARCH_KEY      ""
 #endif
+#ifndef MIMI_SECRET_FEISHU_APP_ID
+#define MIMI_SECRET_FEISHU_APP_ID   ""
+#endif
+#ifndef MIMI_SECRET_FEISHU_APP_SECRET
+#define MIMI_SECRET_FEISHU_APP_SECRET ""
+#endif
 
 /* WiFi */
 #define MIMI_WIFI_MAX_RETRY          10
@@ -79,6 +85,11 @@
 #define MIMI_CONTEXT_BUF_SIZE        (16 * 1024)
 #define MIMI_SESSION_MAX_MSGS        20
 
+/* Feishu Bot */
+#define MIMI_FEISHU_STACK            (12 * 1024)
+#define MIMI_FEISHU_PRIO             5
+#define MIMI_FEISHU_CORE             0
+
 /* WebSocket Gateway */
 #define MIMI_WS_PORT                 18789
 #define MIMI_WS_MAX_CLIENTS          4
@@ -94,6 +105,7 @@
 #define MIMI_NVS_LLM                 "llm_config"
 #define MIMI_NVS_PROXY               "proxy_config"
 #define MIMI_NVS_SEARCH              "search_config"
+#define MIMI_NVS_FEISHU              "feishu_config"
 
 /* NVS Keys */
 #define MIMI_NVS_KEY_SSID            "ssid"
@@ -103,4 +115,6 @@
 #define MIMI_NVS_KEY_MODEL           "model"
 #define MIMI_NVS_KEY_PROXY_HOST      "host"
 #define MIMI_NVS_KEY_PROXY_PORT      "port"
+#define MIMI_NVS_KEY_FEISHU_APP_ID   "app_id"
+#define MIMI_NVS_KEY_FEISHU_SECRET   "app_secret"
 

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -27,3 +27,7 @@
 
 /* Brave Search API */
 #define MIMI_SECRET_SEARCH_KEY      ""
+
+/* Feishu (Lark) Bot */
+#define MIMI_SECRET_FEISHU_APP_ID    ""
+#define MIMI_SECRET_FEISHU_APP_SECRET ""


### PR DESCRIPTION
- Implement Feishu bot using WebSocket long connection (no public IP needed)
- Hand-rolled protobuf codec for Feishu's binary frame protocol
- Auto tenant_access_token refresh, message dedup, 120s ping heartbeat
- Send replies via Feishu REST API (supports 1-on-1 and group chats)
- CLI commands: set_feishu_id, set_feishu_secret
- Add bilingual setup guide (docs/FEISHU.md)
- Update READMEs with Feishu in architecture diagram, features, and CLI docs

Closes #9