### PR TITLE
feat: add flash encryption and NVS encryption for token protection

### DIFF
--- a/partitions.csv
+++ b/partitions.csv
@@ -1,8 +1,9 @@
-# Name,    Type, SubType, Offset,   Size
-nvs,       data, nvs,     0x9000,   0x6000
-otadata,   data, ota,     0xF000,   0x2000
-phy_init,  data, phy,     0x11000,  0x1000
-ota_0,     app,  ota_0,   0x20000,  0x200000
+# Name,    Type, SubType,  Offset,   Size
+nvs,       data, nvs,      0x9000,   0x6000
+otadata,   data, ota,      0xF000,   0x2000
+phy_init,  data, phy,      0x11000,  0x1000
+nvs_keys,  data, nvs_keys, 0x12000,  0x1000
+ota_0,     app,  ota_0,    0x20000,  0x200000
 ota_1,     app,  ota_1,   0x220000, 0x200000
 spiffs,    data, spiffs,  0x420000, 0xBD0000
 coredump,  data, coredump,0xFF0000, 0x10000

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,5 +35,15 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
+# Flash Encryption (Development Mode)
+# Protects all flash contents (including NVS tokens) from physical extraction.
+# The encryption key is stored in eFuse and cannot be read back.
+# Development mode allows reflashing; Release mode is permanent.
+CONFIG_SECURE_FLASH_ENC_ENABLED=y
+CONFIG_SECURE_FLASH_ENCRYPTION_MODE_DEVELOPMENT=y
+
+# NVS Encryption (uses keys from nvs_keys partition, protected by flash encryption)
+CONFIG_NVS_ENCRYPTION=y
+
 # Console/UART for CLI
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y


### PR DESCRIPTION
Protect NVS-stored secrets (API keys, tokens, WiFi credentials) from physical extraction by enabling ESP32-S3 flash encryption (dev mode) and NVS encryption. The init_nvs() function auto-detects flash encryption at runtime and falls back to plain NVS when disabled.