### PR TITLE
feat: support Qwen LLM provider

### DIFF
--- a/main/llm/llm_proxy.h
+++ b/main/llm/llm_proxy.h
@@ -18,7 +18,7 @@ esp_err_t llm_proxy_init(void);
 esp_err_t llm_set_api_key(const char *api_key);
 
 /**
- * Save the LLM provider to NVS. (e.g. "anthropic", "openai")
+ * Save the LLM provider to NVS. (e.g. "anthropic", "openai", "qwen")
  */
 esp_err_t llm_set_provider(const char *provider);
 
@@ -51,8 +51,9 @@ typedef struct {
 typedef struct {
     char *text;                                  /* accumulated text blocks */
     size_t text_len;
-    llm_tool_call_t calls[MIMI_MAX_TOOL_CALLS];
+    llm_tool_call_t *calls;                      /* dynamic array of tool calls */
     int call_count;
+    int call_capacity;                           /* allocated capacity */
     bool tool_use;                               /* stop_reason == "tool_use" */
 } llm_response_t;
 

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -34,6 +34,12 @@
 #ifndef MIMI_SECRET_SEARCH_KEY
 #define MIMI_SECRET_SEARCH_KEY      ""
 #endif
+#ifndef MIMI_SECRET_QWEN_API_KEY
+#define MIMI_SECRET_QWEN_API_KEY    ""
+#endif
+#ifndef MIMI_SECRET_QWEN_MODEL
+#define MIMI_SECRET_QWEN_MODEL      ""
+#endif
 
 /* WiFi */
 #define MIMI_WIFI_MAX_RETRY          10
@@ -66,6 +72,12 @@
 #define MIMI_OPENAI_API_URL          "https://api.openai.com/v1/chat/completions"
 #define MIMI_LLM_API_VERSION         "2023-06-01"
 #define MIMI_LLM_STREAM_BUF_SIZE     (32 * 1024)
+
+/* LLM - Qwen (Alibaba) */
+#define MIMI_QWEN_DEFAULT_MODEL      "qwen-plus"
+#define MIMI_QWEN_MAX_TOKENS         4096
+#define MIMI_QWEN_API_URL            "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions"
+#define MIMI_QWEN_STREAM_BUF_SIZE    (32 * 1024)
 
 /* Message Bus */
 #define MIMI_BUS_QUEUE_LEN           8

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -17,10 +17,14 @@
 /* Telegram Bot */
 #define MIMI_SECRET_TG_TOKEN        ""
 
-/* Anthropic API */
+/* Anthropic API (Claude) */
 #define MIMI_SECRET_API_KEY         ""
 #define MIMI_SECRET_MODEL           ""
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
+
+/* Alibaba Qwen API */
+#define MIMI_SECRET_QWEN_API_KEY    ""
+#define MIMI_SECRET_QWEN_MODEL      ""
 
 /* HTTP Proxy (leave empty or set both) */
 #define MIMI_SECRET_PROXY_HOST      ""


### PR DESCRIPTION
## Summary
- add Qwen as an OpenAI-compatible LLM provider
- provide Qwen defaults and secrets/config hooks

## Changes
- route Qwen via provider-aware API URL/host/path selection
- add Qwen defaults in config and secrets template updates
- adjust max tokens selection per provider

## Testing
- not run

## Summary by CodeRabbit
### New Features
- added Qwen (Alibaba) as a supported LLM provider option
- implemented unified multi-provider architecture supporting OpenAI-compatible and other LLM backends

### Improvements
- updated tool call storage from fixed arrays to dynamic allocation for enhanced flexibility

## Issues
- Closes #33