### PR TITLE
feat: add socks5 proxy support

### DIFF
--- a/main/proxy/http_proxy.h
+++ b/main/proxy/http_proxy.h
@@ -15,9 +15,9 @@ esp_err_t http_proxy_init(void);
 bool http_proxy_is_enabled(void);
 
 /**
- * Save proxy host and port to NVS.
+ * Save proxy host, port, and type to NVS.
  */
-esp_err_t http_proxy_set(const char *host, uint16_t port);
+esp_err_t http_proxy_set(const char *host, uint16_t port, const char *type);
 
 /**
  * Remove proxy config from NVS.


### PR DESCRIPTION
add socks5 proxy support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SOCKS5 proxy support as an alternative to HTTP proxies.
  * Proxy type is now configurable and persistently stored for consistent proxy settings across device sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->