### PR TITLE
fix(agent): move context builder buffers from stack to PSRAM

### DIFF
--- a/main/agent/context_builder.c
+++ b/main/agent/context_builder.c
@@ -10,6 +10,9 @@
 
 static const char *TAG = "context";
 
+/** Append the contents of a SPIFFS file into buf at the given offset.
+ *  If header is non-NULL, a markdown section header is written first.
+ *  Returns the new offset after appending. */
 static size_t append_file(char *buf, size_t size, size_t offset, const char *path, const char *header)
 {
     FILE *f = fopen(path, "r");
@@ -26,6 +29,10 @@ static size_t append_file(char *buf, size_t size, size_t offset, const char *pat
     return offset;
 }
 
+/** Build the full system prompt into buf (up to size bytes).
+ *  Combines the static instructions, personality/user files, long-term
+ *  memory, recent daily notes, and skill summaries. Temporary read
+ *  buffers are allocated from PSRAM to avoid overflowing the task stack. */
 esp_err_t context_build_system_prompt(char *buf, size_t size)
 {
     size_t off = 0;


### PR DESCRIPTION
## Summary

The `context_build_system_prompt()` function in `agent/context_builder.c` allocated approximately 10 KB of temporary buffers as local (stack) variables:

- `mem_buf[4096]` — for reading long-term memory
- `recent_buf[4096]` — for reading recent daily notes
- `skills_buf[2048]` — for building the skills summary

The `agent_loop` task runs with a 12 KB stack (`MIMI_AGENT_STACK`), which leaves almost no headroom after these allocations. When a message arrives and the agent processes it, the deep call chain (SPIFFS reads, flash operations, directory scanning) pushes the stack over the limit, causing either:

1. **Stack overflow panic** — `vApplicationStackOverflowHook` triggers an immediate abort
2. **Interrupt watchdog timeout** — heap metadata corruption from stack overflow causes `multi_heap_get_info_tlsf` to hang on CPU1, starving the IDLE task

Both crashes are reproducible on every incoming Telegram message.

## Changes

- Replace the three stack-allocated buffers with `heap_caps_calloc()` calls targeting PSRAM (`MALLOC_CAP_SPIRAM`)
- Add NULL checks before using each buffer (graceful degradation if PSRAM allocation fails)
- Free all three buffers before returning
- Add `#include "esp_heap_caps.h"` for the allocation API

This follows the same pattern already used in `agent_loop_task()` (lines 85-87), where `system_prompt`, `history_json`, and `tool_output` are allocated from PSRAM.

## Impact

- **Before:** Every Telegram message triggers a panic and reboot
- **After:** Agent processes messages normally with ~8 MB PSRAM headroom

No changes to the public API or configuration. The fix is purely internal to the context builder.

## Test plan

- [ ] Build compiles without warnings
- [ ] Send a Telegram message — agent processes it without crash
- [ ] Verify PSRAM usage is reported in agent loop logs (`Free PSRAM: ...`)
- [ ] Confirm no stack overflow or watchdog errors in serial monitor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Buffer allocations moved to external PSRAM to reduce stack use and improve stability on memory-constrained devices.

* **Bug Fixes**
  * Added validation and null-checks to prevent crashes from unallocated buffers and ensure safe memory handling.

* **New Features**
  * Improved loading of long-term memory and recent notes when available; skills are built only if content exists.

* **User-facing**
  * Skills section no longer appears empty or garbled.

* **Documentation**
  * Added comments clarifying memory and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->