### PR TITLE
fix: prevent device hang when no USB host connected

### DIFF
--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -552,11 +552,11 @@ esp_err_t serial_cli_init(void)
     repl_config.prompt = "mimi> ";
     repl_config.max_cmdline_length = 256;
 
-    /* USB Serial JTAG */
-    esp_console_dev_usb_serial_jtag_config_t hw_config =
-        ESP_CONSOLE_DEV_USB_SERIAL_JTAG_CONFIG_DEFAULT();
+    /* UART console (primary), USB Serial/JTAG available as secondary */
+    esp_console_dev_uart_config_t hw_config =
+        ESP_CONSOLE_DEV_UART_CONFIG_DEFAULT();
 
-    ESP_ERROR_CHECK(esp_console_new_repl_usb_serial_jtag(&hw_config, &repl_config, &repl));
+    ESP_ERROR_CHECK(esp_console_new_repl_uart(&hw_config, &repl_config, &repl));
 
     /* Register commands */
     esp_console_register_help_command();

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,5 +35,7 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# Console/UART for CLI
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+# Console: UART primary (non-blocking), USB Serial/JTAG secondary
+# Prevents device hang when no USB host is connected (issue #60)
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y


### PR DESCRIPTION
## Summary
- Switch primary console from USB Serial/JTAG to UART to prevent blocking when no USB host is connected
- Keep USB Serial/JTAG as secondary console so `idf.py monitor` and CLI still work when plugged into a computer
- Update `serial_cli.c` to use UART REPL driver

Closes #60

## Test plan
- [ ] Flash firmware, connect to computer → verify `idf.py monitor` and CLI commands work
- [ ] Unplug from computer, plug into wall charger → verify device responds to Telegram messages
- [ ] Verify WiFi connects and all services start without USB host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console serial communication now uses UART as the primary interface, replacing the previous USB Serial/JTAG backend
  * Console initialization and configuration updated to leverage the UART-based connection method  
  * USB Serial/JTAG remains available as a secondary interface option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->