### PR TITLE
Change network hostname from 'espressif' to 'mimiclaw'

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,2 +1,5 @@
 # MimiClaw - Common Default Configuration
 # Target-specific settings are in sdkconfig.defaults.esp32s3
+
+# Network hostname
+CONFIG_LWIP_LOCAL_HOSTNAME="mimiclaw"


### PR DESCRIPTION
Small change to sdkconfig.defaults that helps make this device more identifiable on the local network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced new network hostname configuration parameter to the device settings. This update enables the device to be uniquely identified with a custom hostname on the network, improving network accessibility and device discovery. Enhanced network management and integration capabilities are now fully supported for better overall network operations and device accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->