### PR TITLE
fix: ESP32-S3 freezes on wall charger due to blocking USB Serial/JTAG log writes

### DIFF
--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,7 +35,9 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# Console: UART primary (non-blocking), USB Serial/JTAG secondary
-# Prevents device hang when no USB host is connected (issue #60)
+# Console: UART only (non-blocking, works without a USB host)
+# Using USB Serial/JTAG as secondary console causes esp_log writes to block
+# when the TX FIFO is full and no USB host is connected (wall charger / power bank),
+# completely freezing the device. UART is always non-blocking regardless of USB state.
 CONFIG_ESP_CONSOLE_UART_DEFAULT=y
-CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+CONFIG_ESP_CONSOLE_SECONDARY_NONE=y


### PR DESCRIPTION
When powered by a wall charger or power bank (no USB host), the device freezes at the first `ESP_LOGI()` call in `app_main()` because `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y` routes all `esp_log` output to USB Serial/JTAG — whose TX FIFO blocks indefinitely when no host is draining it.

## Changes

- **`sdkconfig.defaults.esp32s3`**: Replace `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y` with `CONFIG_ESP_CONSOLE_SECONDARY_NONE=y`. Eliminates USB Serial/JTAG peripheral initialization entirely; all log output goes to UART, which is non-blocking regardless of USB state.

```diff
-CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+CONFIG_ESP_CONSOLE_SECONDARY_NONE=y
```

- **`docs/ARCHITECTURE.md`**: Correct task table entry from "USB serial console REPL" → "UART console REPL".
