### PR TITLE
hotfix(proxy): fix CLI/api mismatch and add proxy type defaults

### DIFF
--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -31,6 +31,9 @@
 #ifndef MIMI_SECRET_PROXY_PORT
 #define MIMI_SECRET_PROXY_PORT      ""
 #endif
+#ifndef MIMI_SECRET_PROXY_TYPE
+#define MIMI_SECRET_PROXY_TYPE      ""
+#endif
 #ifndef MIMI_SECRET_SEARCH_KEY
 #define MIMI_SECRET_SEARCH_KEY      ""
 #endif

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -25,6 +25,7 @@
 /* HTTP Proxy (leave empty or set both) */
 #define MIMI_SECRET_PROXY_HOST      ""
 #define MIMI_SECRET_PROXY_PORT      ""
+#define MIMI_SECRET_PROXY_TYPE      ""   /* "http" or "socks5" */
 
 /* Brave Search API */
 #define MIMI_SECRET_SEARCH_KEY      ""


### PR DESCRIPTION
This hotfix fixes the proxy build break on main after SOCKS5 support was added.

It resolves two compatibility issues:

- set_proxy in CLI now matches the updated http_proxy_set(host, port, type) API and supports an optional proxy type (http or socks5, default http).
- MIMI_SECRET_PROXY_TYPE now has a safe default in config and is documented in mimi_secrets.h.example, preventing compile errors when the macro is not defined.

With these changes, the ESP32-S3 build path is back to green and proxy configuration remains backward-friendly for existing CLI usage.

refer PR: https://github.com/memovai/mimiclaw/pull/39

cc @mdreamfly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional proxy type parameter to proxy configuration. Users can now specify proxy type when setting up proxies, with support for "http" and "socks5" options.
  * Includes input validation to ensure only valid proxy types are accepted.

* **Chores**
  * Updated configuration examples and build-time settings to accommodate new proxy type configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->