### PR TITLE
Fix large responses that break web_search tool

### DIFF
--- a/main/tools/tool_web_search.c
+++ b/main/tools/tool_web_search.c
@@ -176,7 +176,7 @@ static esp_err_t search_via_proxy(const char *path, search_buf_t *sb)
     proxy_conn_t *conn = proxy_conn_open("api.search.brave.com", 443, 15000);
     if (!conn) return ESP_ERR_HTTP_CONNECT;
 
-    char header[512];
+    char header[768];
     int hlen = snprintf(header, sizeof(header),
         "GET %s HTTP/1.1\r\n"
         "Host: api.search.brave.com\r\n"


### PR DESCRIPTION
The web_search tool frequently fails because the responses from the Brave Web API are too large to store and parse. When a response is larger than the 16k response buffer, the result is an incomplete JSON fragment that fails to parse.

Fix this with two changes:

1. Provide a 'result_filter=web' filter parameter with the query. This omits Brave Web API results for news, videos, discussions, faqs, and other results that are not parsed by the web_tool. Only web results are returned.

2. Increase the response buffer from 16kb to 64kb. I ran a few queries and the max response size I saw was 58kb.

There's two possible future optimizations not covered in this fix: Adding the "Accept-Encoding: gzip" header to received a compressed response. This would reduce the network traffic and required size for the response buffer. But, we'd still need a large internal buffer to inflate the response before parsing JSON. Next, most results from the Brave Web API have an 'extra_snippets' field which includes a summary of the result. This seems like useful additional context to provide to the agent.

A web_search query for "Bitcoin price" now successfully returns the following response to the agent (tested by adding a debug log in the agent loop)

----------------------------------------------------------------------------- 

> I (635063) agent: Tool web_search response:
> 1. Bitcoin price today, BTC to USD live price, marketcap and chart | CoinMarketCap https://coinmarketcap.com/currencies/bitcoin/ The live Bitcoin price today is <strong>$64,871.55 USD</strong> with a 24-hour trading volume of $45,314,283,881 USD. We update our BTC to USD price in real-time. Bitcoin is down 3.74% in the last 24 hours.
> 
> 2. Bitcoin price today, BTC to USD live price, marketcap and chart | CoinDesk https://www.coindesk.com/price/bitcoin The price of Bitcoin (BTC) is <strong>$63,508.01</strong> today as of Feb 24, 2026, 12:15 am EST, with a 24-hour trading volume of $24.62B.
> 
> 3. Bitcoin BTC (BTC-USD) Live Price, News, Chart & Price History - Yahoo Finance https://finance.yahoo.com/quote/BTC-USD/ Bitcoin has a current supply of 19,993,606. The last known price of Bitcoin is <strong>66,178.39249005 USD</strong> and is down -2.15 over the last 24 hours. It is currently trading on 12564 active market(s) with $39,417,837,545.32 traded over the last 24 hours.
> 
> 4. Bitcoin Price Chart (BTC/USD) | Bitcoin Value | bitFlyer USA https://bitflyer.com/en-us/bitcoin-chart Check out the current Bitcoin (BTC) price, market cap, historical volatility, and buy Bitcoin on bitFlyer today with <strong>as little as $1</strong>!
> 
> 5. Bitcoin Price | BTC to USD Converter, Chart and News https://www.binance.com/en/price/bitcoin Live price of Bitcoin is <strong>$96,262.14</strong> with a market cap of $1,908.19B USD. Discover current price, trading volume, chart history, and more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Handles much larger web search responses and warns on potential overflow to avoid truncation.
  * Fewer crashes and leaks thanks to improved out-of-memory handling and cleaner error/cleanup paths.

* **Refactor**
  * More robust URL construction, encoding, and request logic for both proxied and direct requests, improving stability and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->