### PR TITLE
Exit console REPL when USB serial JTAG not connected

### DIFF
--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -19,6 +19,7 @@
 #include "esp_log.h"
 #include "esp_console.h"
 #include "esp_system.h"
+#include "driver/usb_serial_jtag.h"
 #include "esp_heap_caps.h"
 #include "nvs_flash.h"
 #include "nvs.h"
@@ -557,6 +558,13 @@ static int cmd_restart(int argc, char **argv)
 
 esp_err_t serial_cli_init(void)
 {
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    if (!usb_serial_jtag_is_connected()) {
+        ESP_LOGI(TAG, "USB host not connected, skipping console REPL");
+        return ESP_OK;
+    }
+#endif
+
     esp_console_repl_t *repl = NULL;
     esp_console_repl_config_t repl_config = ESP_CONSOLE_REPL_CONFIG_DEFAULT();
     repl_config.prompt = "mimi> ";

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,7 +35,5 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# Console: UART primary (non-blocking), USB Serial/JTAG secondary
-# Prevents device hang when no USB host is connected (issue #60)
-CONFIG_ESP_CONSOLE_UART_DEFAULT=y
-CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+# Console: USB Serial/JTAG
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y


### PR DESCRIPTION
With the current sdkconfig setting of:
CONFIG_ESP_CONSOLE_UART_DEFAULT=y
CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
Logs go to the idf.py monitor, but the console REPL is not functional. It is not possible to enter any input from the idf.py monitor.

With CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y, the console REPL functions correctly. When no USB host is connected, logs are dropped. See usb_serial_jtag_vfs.c. The VFS write function checks connection status before writing:
```
static ssize_t usb_serial_jtag_write(int fd, const void * data, size_t size)
{
  if (!usb_serial_jtag_is_connected()) {
      return -1;  // drops immediately
  }

}
```

However, when no USB host is connected, serial_cli_init() does not return. This blocks the start of WiFi, the agent loop, and telegram. This is because the REPL enters a tight busy loop:
  1. linenoiseProbe() spends 500ms polling for a terminal response that never comes, then sets dumb mode
  2. In dumb mode, linenoiseDumb() writes the prompt (dropped immediately via usb_serial_jtag_is_connected() check) then calls read() which also returns -1 immediately
  3. linenoise() returns NULL, the loop repeats
  4. Each iteration does a calloc + free for the line buffer

Let's assume that we don't need the console REPL when USB host is not connected. Add a check in serial_cli_init() for usb_serial_jtag_is_connected() (gated by the CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG define). If this check matches, then exit this function early, before starting the console REPL task. The agent loop and rest of the mimiclaw system starts up and runs successfully without the console REPL task.

This boot time check means that you cannot power on the esp32s3, then later connect to a computer to get a REPL. However, this seems like acceptable behavior to enable both logs and a REPL while connected to a computer and successful operation while not connected to a USB host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console now defaults to USB Serial/JTAG interface on ESP32S3 devices.

* **Bug Fixes**
  * Improved console initialization when USB host is unavailable, preventing unnecessary setup delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->