### PR TITLE
fix: add missing stdlib.h include in heartbeat.c

### DIFF
--- a/main/heartbeat/heartbeat.c
+++ b/main/heartbeat/heartbeat.c
@@ -3,6 +3,7 @@
 #include "bus/message_bus.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 #include <ctype.h>


### PR DESCRIPTION
The code calls free() without including <stdlib.h>, which triggers implicit declaration warnings during the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a compilation issue affecting heartbeat functionality, ensuring proper memory allocation and operation of heartbeat transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->