### PR TITLE
Fix: add missing library

### DIFF
--- a/main/gateway/ws_server.c
+++ b/main/gateway/ws_server.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include "esp_log.h"
 #include "esp_http_server.h"
 #include "cJSON.h"


### PR DESCRIPTION
One missing include: `stdbool.h` is not listed, but `bool` and `true/false` are used in the `ws_client_t` struct and throughout the file. In C99/C11 these require `stdbool.h` unless pulled in transitively:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal compilation improvement to support boolean type handling.

---

**Note:** This release contains primarily internal maintenance updates with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->