### PR TITLE
feat: add dual-board ESP-NOW architecture for Python script execution

### DIFF
--- a/executor/README.md
+++ b/executor/README.md
@@ -1,0 +1,70 @@
+# Board B - MicroPython Executor
+
+Board B is an ESP32 (or ESP32-S3) running MicroPython that receives Python scripts from Board A (MimiClaw) via ESP-NOW and executes them.
+
+## Requirements
+
+- ESP32 or ESP32-S3 board
+- MicroPython firmware with ESP-NOW support (v1.20+)
+
+## Setup
+
+### 1. Flash MicroPython firmware
+
+Download the latest MicroPython firmware for your board from https://micropython.org/download/
+
+```bash
+# Erase flash
+esptool.py --chip esp32s3 erase_flash
+
+# Flash MicroPython (adjust firmware filename)
+esptool.py --chip esp32s3 write_flash -z 0 ESP32_GENERIC_S3-20240602-v1.23.0.bin
+```
+
+### 2. Upload scripts
+
+```bash
+# Install mpremote
+pip install mpremote
+
+# Upload boot.py and main.py
+mpremote cp boot.py :boot.py
+mpremote cp main.py :main.py
+
+# Reset the board
+mpremote reset
+```
+
+### 3. Get Board B MAC address
+
+After uploading and resetting, Board B will print its MAC address:
+
+```
+Board B MAC: aa:bb:cc:dd:ee:ff
+On Board A, run: set_espnow_peer aa:bb:cc:dd:ee:ff
+```
+
+### 4. Configure Board A
+
+On Board A's serial console:
+
+```
+set_espnow_peer aa:bb:cc:dd:ee:ff
+restart
+```
+
+## How It Works
+
+1. Board A's AI agent decides to run a Python script (via `run_python` tool)
+2. The script is sent to Board B over ESP-NOW (chunked, 243 bytes per packet)
+3. Board B receives and reassembles the script
+4. Board B executes the script with `exec()`, capturing stdout
+5. The result (stdout + any exceptions) is sent back to Board A
+6. Board A returns the result to the AI agent
+
+## Limitations
+
+- ESP-NOW range: ~200m line of sight, ~50m indoors
+- MicroPython memory: limited by Board B's available RAM
+- No persistent state between script executions (each `exec()` gets a fresh namespace)
+- No WiFi connection on Board B (WiFi STA is active but not connected, used only for ESP-NOW)

--- a/executor/boot.py
+++ b/executor/boot.py
@@ -1,0 +1,18 @@
+"""
+MimiClaw Board B (Executor) - boot.py
+Initializes WiFi STA interface for ESP-NOW (no connection needed).
+Prints MAC address for pairing with Board A.
+"""
+
+import network
+import ubinascii
+
+# Enable WiFi STA (required for ESP-NOW, but no need to connect)
+sta = network.WLAN(network.STA_IF)
+sta.active(True)
+
+# Print MAC address for Board A configuration
+mac = sta.config('mac')
+mac_str = ubinascii.hexlify(mac, ':').decode()
+print('Board B MAC:', mac_str)
+print('On Board A, run: set_espnow_peer', mac_str)

--- a/executor/main.py
+++ b/executor/main.py
@@ -1,0 +1,157 @@
+"""
+MimiClaw Board B (Executor) - main.py
+Listens for Python scripts via ESP-NOW from Board A, executes them,
+and sends back the result (stdout + exceptions).
+
+Protocol:
+  Header (7 bytes): [type(1) | seq(2 LE) | total_len(4 LE)]
+  Types: 0x01=SCRIPT_START, 0x02=SCRIPT_CHUNK, 0x03=SCRIPT_END
+         0x11=RESULT_START, 0x12=RESULT_CHUNK, 0x13=RESULT_END
+"""
+
+import espnow
+import network
+import sys
+import io
+import struct
+import time
+
+# --- Constants ---
+MSG_SCRIPT_START = 0x01
+MSG_SCRIPT_CHUNK = 0x02
+MSG_SCRIPT_END   = 0x03
+MSG_RESULT_START = 0x11
+MSG_RESULT_CHUNK = 0x12
+MSG_RESULT_END   = 0x13
+
+HEADER_SIZE = 7
+MAX_PAYLOAD = 250
+CHUNK_DATA  = MAX_PAYLOAD - HEADER_SIZE
+
+# --- ESP-NOW Setup ---
+sta = network.WLAN(network.STA_IF)
+sta.active(True)
+
+e = espnow.ESPNow()
+e.active(True)
+
+# Board A peer - will be set on first received message
+peer_mac = None
+
+
+def build_header(msg_type, seq, total_len=0):
+    return struct.pack('<BHI', msg_type, seq, total_len)
+
+
+def send_result(mac, result_text):
+    """Send result back to Board A in chunks."""
+    data = result_text.encode('utf-8')
+    total = len(data)
+    offset = 0
+    seq = 0
+
+    while offset < total:
+        chunk_size = min(CHUNK_DATA, total - offset)
+        is_first = (seq == 0)
+        is_last = (offset + chunk_size >= total)
+
+        if is_first:
+            msg_type = MSG_RESULT_START
+        elif is_last:
+            msg_type = MSG_RESULT_END
+        else:
+            msg_type = MSG_RESULT_CHUNK
+
+        header = build_header(msg_type, seq, total if is_first else 0)
+        pkt = header + data[offset:offset + chunk_size]
+
+        try:
+            e.send(mac, pkt)
+        except Exception as ex:
+            print('ESP-NOW send error:', ex)
+            return
+
+        offset += chunk_size
+        seq += 1
+        if not is_last:
+            time.sleep_ms(5)
+
+    # Handle empty result
+    if total == 0:
+        header = build_header(MSG_RESULT_START, 0, 0)
+        e.send(mac, header)
+        header = build_header(MSG_RESULT_END, 1, 0)
+        e.send(mac, header)
+
+
+def execute_script(code):
+    """Execute Python code and capture stdout + exceptions."""
+    old_stdout = sys.stdout
+    captured = io.StringIO()
+    sys.stdout = captured
+
+    try:
+        exec(code, {'__name__': '__main__'})
+    except Exception as ex:
+        print('Error:', type(ex).__name__, '-', ex)
+    finally:
+        sys.stdout = old_stdout
+
+    return captured.getvalue()
+
+
+# --- Main Loop ---
+print('Board B executor ready. Waiting for scripts...')
+
+script_buf = bytearray()
+script_total = 0
+script_seq = 0
+receiving = False
+
+while True:
+    mac, msg = e.recv(timeout_ms=1000)
+    if msg is None:
+        continue
+
+    if len(msg) < HEADER_SIZE:
+        continue
+
+    msg_type, seq, total_len = struct.unpack('<BHI', msg[:HEADER_SIZE])
+    payload = msg[HEADER_SIZE:]
+
+    # Remember the peer
+    if peer_mac is None and mac is not None:
+        peer_mac = bytes(mac)
+        try:
+            e.add_peer(peer_mac)
+        except Exception:
+            pass  # peer may already exist
+        print('Paired with Board A:', ':'.join('%02x' % b for b in peer_mac))
+
+    if msg_type == MSG_SCRIPT_START:
+        script_total = total_len
+        script_buf = bytearray(payload)
+        script_seq = seq + 1
+        receiving = True
+
+    elif msg_type == MSG_SCRIPT_CHUNK and receiving:
+        if seq == script_seq:
+            script_buf.extend(payload)
+            script_seq = seq + 1
+
+    elif msg_type == MSG_SCRIPT_END:
+        if payload:
+            script_buf.extend(payload)
+
+        code = bytes(script_buf).decode('utf-8')
+        print('Received script ({} bytes), executing...'.format(len(code)))
+
+        result = execute_script(code)
+        print('Result ({} bytes): {}'.format(len(result), result[:100]))
+
+        if peer_mac:
+            send_result(peer_mac, result)
+
+        # Reset state
+        script_buf = bytearray()
+        receiving = False

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -20,6 +20,8 @@ idf_component_register(
         "tools/tool_web_search.c"
         "tools/tool_get_time.c"
         "tools/tool_files.c"
+        "tools/tool_run_python.c"
+        "espnow/espnow_manager.c"
         "skills/skill_loader.c"
     INCLUDE_DIRS
         "."

--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -12,6 +12,7 @@
 #include "cron/cron_service.h"
 #include "heartbeat/heartbeat.h"
 #include "skills/skill_loader.h"
+#include "espnow/espnow_manager.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -541,6 +542,24 @@ static int cmd_config_show(int argc, char **argv)
     print_config("Proxy Port", MIMI_NVS_PROXY,  MIMI_NVS_KEY_PROXY_PORT, MIMI_SECRET_PROXY_PORT, false);
     print_config("Search Key", MIMI_NVS_SEARCH, MIMI_NVS_KEY_API_KEY,  MIMI_SECRET_SEARCH_KEY, true);
     print_config("Tavily Key", MIMI_NVS_SEARCH, MIMI_NVS_KEY_TAVILY_KEY, MIMI_SECRET_TAVILY_KEY, true);
+
+    /* ESP-NOW peer MAC */
+    {
+        uint8_t mac[6] = {0};
+        nvs_handle_t nvs;
+        if (nvs_open(MIMI_NVS_ESPNOW, NVS_READONLY, &nvs) == ESP_OK) {
+            size_t len = 6;
+            if (nvs_get_blob(nvs, MIMI_NVS_KEY_PEER_MAC, mac, &len) == ESP_OK && len == 6) {
+                printf("  %-14s: %02x:%02x:%02x:%02x:%02x:%02x  [NVS]\n", "ESP-NOW Peer",
+                       mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+            } else {
+                printf("  %-14s: (not set)\n", "ESP-NOW Peer");
+            }
+            nvs_close(nvs);
+        } else {
+            printf("  %-14s: (not set)\n", "ESP-NOW Peer");
+        }
+    }
     printf("=============================\n");
     return 0;
 }
@@ -549,9 +568,9 @@ static int cmd_config_show(int argc, char **argv)
 static int cmd_config_reset(int argc, char **argv)
 {
     const char *namespaces[] = {
-        MIMI_NVS_WIFI, MIMI_NVS_TG, MIMI_NVS_LLM, MIMI_NVS_PROXY, MIMI_NVS_SEARCH
+        MIMI_NVS_WIFI, MIMI_NVS_TG, MIMI_NVS_FEISHU, MIMI_NVS_LLM, MIMI_NVS_PROXY, MIMI_NVS_SEARCH, MIMI_NVS_ESPNOW
     };
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 7; i++) {
         nvs_handle_t nvs;
         if (nvs_open(namespaces[i], NVS_READWRITE, &nvs) == ESP_OK) {
             nvs_erase_all(nvs);
@@ -740,6 +759,45 @@ static int cmd_web_search(int argc, char **argv)
     printf("%s\n", output[0] ? output : "(empty)");
     free(output);
     return (err == ESP_OK) ? 0 : 1;
+}
+
+/* --- set_espnow_peer command --- */
+static struct {
+    struct arg_str *mac;
+    struct arg_end *end;
+} espnow_peer_args;
+
+static int cmd_set_espnow_peer(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&espnow_peer_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, espnow_peer_args.end, argv[0]);
+        return 1;
+    }
+
+    const char *mac_str = espnow_peer_args.mac->sval[0];
+    uint8_t mac[6];
+    int parsed = sscanf(mac_str, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+                        &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+    if (parsed != 6) {
+        printf("Invalid MAC format. Use XX:XX:XX:XX:XX:XX\n");
+        return 1;
+    }
+
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(MIMI_NVS_ESPNOW, NVS_READWRITE, &nvs);
+    if (err != ESP_OK) {
+        printf("NVS open failed: %s\n", esp_err_to_name(err));
+        return 1;
+    }
+    nvs_set_blob(nvs, MIMI_NVS_KEY_PEER_MAC, mac, 6);
+    nvs_commit(nvs);
+    nvs_close(nvs);
+
+    printf("ESP-NOW peer MAC saved: %02x:%02x:%02x:%02x:%02x:%02x\n",
+           mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    printf("Restart to apply.\n");
+    return 0;
 }
 
 /* --- restart command --- */
@@ -1040,6 +1098,17 @@ esp_err_t serial_cli_init(void)
         .argtable = &web_search_args,
     };
     esp_console_cmd_register(&web_search_cmd);
+
+    /* set_espnow_peer */
+    espnow_peer_args.mac = arg_str1(NULL, NULL, "<mac>", "Board B MAC (XX:XX:XX:XX:XX:XX)");
+    espnow_peer_args.end = arg_end(1);
+    esp_console_cmd_t espnow_peer_cmd = {
+        .command = "set_espnow_peer",
+        .help = "Set ESP-NOW peer MAC for Board B (e.g. set_espnow_peer AA:BB:CC:DD:EE:FF)",
+        .func = &cmd_set_espnow_peer,
+        .argtable = &espnow_peer_args,
+    };
+    esp_console_cmd_register(&espnow_peer_cmd);
 
     /* restart */
     esp_console_cmd_t restart_cmd = {

--- a/main/espnow/espnow_manager.c
+++ b/main/espnow/espnow_manager.c
@@ -1,0 +1,281 @@
+#include "espnow_manager.h"
+#include "mimi_config.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include "esp_log.h"
+#include "esp_now.h"
+#include "esp_wifi.h"
+#include "nvs_flash.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "freertos/semphr.h"
+
+static const char *TAG = "espnow";
+
+/* Chunk payload = 250 (ESP-NOW max) - 7 (header) */
+#define ESPNOW_MAX_PAYLOAD    250
+#define ESPNOW_HEADER_SIZE    7
+#define ESPNOW_CHUNK_DATA     (ESPNOW_MAX_PAYLOAD - ESPNOW_HEADER_SIZE)
+
+/* First chunk header: [type(1) | seq(2) | total_len(4)] */
+/* Continuation:       [type(1) | seq(2) | padding(4)]   */
+
+#define BIT_RESULT_DONE       BIT0
+#define BIT_SEND_OK           BIT1
+#define BIT_SEND_FAIL         BIT2
+
+static bool s_initialized = false;
+static uint8_t s_peer_mac[6] = {0};
+static EventGroupHandle_t s_event_group = NULL;
+static SemaphoreHandle_t s_mutex = NULL;
+
+/* Result reassembly buffer */
+static char *s_result_buf = NULL;
+static size_t s_result_size = 0;
+static size_t s_result_len = 0;
+static uint32_t s_result_total = 0;
+static uint16_t s_result_seq = 0;
+
+static void build_header(uint8_t *buf, uint8_t type, uint16_t seq, uint32_t total_len)
+{
+    buf[0] = type;
+    buf[1] = (uint8_t)(seq & 0xFF);
+    buf[2] = (uint8_t)((seq >> 8) & 0xFF);
+    buf[3] = (uint8_t)(total_len & 0xFF);
+    buf[4] = (uint8_t)((total_len >> 8) & 0xFF);
+    buf[5] = (uint8_t)((total_len >> 16) & 0xFF);
+    buf[6] = (uint8_t)((total_len >> 24) & 0xFF);
+}
+
+static void on_send_cb(const esp_now_send_info_t *tx_info, esp_now_send_status_t status)
+{
+    if (s_event_group) {
+        xEventGroupSetBits(s_event_group,
+                           status == ESP_NOW_SEND_SUCCESS ? BIT_SEND_OK : BIT_SEND_FAIL);
+    }
+}
+
+static void on_recv_cb(const esp_now_recv_info_t *info, const uint8_t *data, int len)
+{
+    if (len < ESPNOW_HEADER_SIZE) return;
+
+    uint8_t type = data[0];
+    uint16_t seq = data[1] | (data[2] << 8);
+    const uint8_t *payload = data + ESPNOW_HEADER_SIZE;
+    int payload_len = len - ESPNOW_HEADER_SIZE;
+
+    switch (type) {
+    case ESPNOW_MSG_RESULT_START: {
+        uint32_t total = data[3] | (data[4] << 8) | (data[5] << 16) | (data[6] << 24);
+        s_result_total = total;
+        s_result_len = 0;
+        s_result_seq = 0;
+        if (payload_len > 0 && s_result_buf && s_result_len + payload_len < s_result_size) {
+            memcpy(s_result_buf + s_result_len, payload, payload_len);
+            s_result_len += payload_len;
+        }
+        s_result_seq = seq + 1;
+        ESP_LOGD(TAG, "Result start: total=%lu", (unsigned long)total);
+        break;
+    }
+    case ESPNOW_MSG_RESULT_CHUNK:
+        if (seq == s_result_seq && s_result_buf && payload_len > 0) {
+            size_t copy = payload_len;
+            if (s_result_len + copy >= s_result_size) {
+                copy = s_result_size - s_result_len - 1;
+            }
+            if (copy > 0) {
+                memcpy(s_result_buf + s_result_len, payload, copy);
+                s_result_len += copy;
+            }
+            s_result_seq = seq + 1;
+        }
+        break;
+    case ESPNOW_MSG_RESULT_END:
+        if (s_result_buf && payload_len > 0) {
+            size_t copy = payload_len;
+            if (s_result_len + copy >= s_result_size) {
+                copy = s_result_size - s_result_len - 1;
+            }
+            if (copy > 0) {
+                memcpy(s_result_buf + s_result_len, payload, copy);
+                s_result_len += copy;
+            }
+        }
+        if (s_result_buf && s_result_len < s_result_size) {
+            s_result_buf[s_result_len] = '\0';
+        }
+        ESP_LOGI(TAG, "Result complete: %u bytes", (unsigned)s_result_len);
+        if (s_event_group) {
+            xEventGroupSetBits(s_event_group, BIT_RESULT_DONE);
+        }
+        break;
+    default:
+        ESP_LOGD(TAG, "Ignoring msg type 0x%02x", type);
+        break;
+    }
+}
+
+static esp_err_t load_peer_mac(void)
+{
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(MIMI_NVS_ESPNOW, NVS_READONLY, &nvs);
+    if (err != ESP_OK) return ESP_ERR_NOT_FOUND;
+
+    size_t len = 6;
+    err = nvs_get_blob(nvs, MIMI_NVS_KEY_PEER_MAC, s_peer_mac, &len);
+    nvs_close(nvs);
+
+    if (err != ESP_OK || len != 6) return ESP_ERR_NOT_FOUND;
+
+    ESP_LOGI(TAG, "Peer MAC: %02x:%02x:%02x:%02x:%02x:%02x",
+             s_peer_mac[0], s_peer_mac[1], s_peer_mac[2],
+             s_peer_mac[3], s_peer_mac[4], s_peer_mac[5]);
+    return ESP_OK;
+}
+
+esp_err_t espnow_manager_init(void)
+{
+    if (s_initialized) return ESP_OK;
+
+    esp_err_t err = load_peer_mac();
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "No ESP-NOW peer configured (use 'set espnow_peer XX:XX:XX:XX:XX:XX')");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    s_event_group = xEventGroupCreate();
+    s_mutex = xSemaphoreCreateMutex();
+    if (!s_event_group || !s_mutex) return ESP_ERR_NO_MEM;
+
+    err = esp_now_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_now_init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    esp_now_register_send_cb(on_send_cb);
+    esp_now_register_recv_cb(on_recv_cb);
+
+    /* Add peer */
+    esp_now_peer_info_t peer = {
+        .channel = MIMI_ESPNOW_CHANNEL,
+        .encrypt = false,
+        .ifidx = WIFI_IF_STA,
+    };
+    memcpy(peer.peer_addr, s_peer_mac, 6);
+
+    err = esp_now_add_peer(&peer);
+    if (err != ESP_OK && err != ESP_ERR_ESPNOW_EXIST) {
+        ESP_LOGE(TAG, "esp_now_add_peer failed: %s", esp_err_to_name(err));
+        esp_now_deinit();
+        return err;
+    }
+
+    s_initialized = true;
+    ESP_LOGI(TAG, "ESP-NOW initialized");
+    return ESP_OK;
+}
+
+bool espnow_is_ready(void)
+{
+    return s_initialized;
+}
+
+static esp_err_t send_chunk_and_wait(const uint8_t *data, size_t len)
+{
+    xEventGroupClearBits(s_event_group, BIT_SEND_OK | BIT_SEND_FAIL);
+
+    esp_err_t err = esp_now_send(s_peer_mac, data, len);
+    if (err != ESP_OK) return err;
+
+    EventBits_t bits = xEventGroupWaitBits(s_event_group,
+                                            BIT_SEND_OK | BIT_SEND_FAIL,
+                                            pdTRUE, pdFALSE,
+                                            pdMS_TO_TICKS(5000));
+    if (bits & BIT_SEND_OK) return ESP_OK;
+    return ESP_FAIL;
+}
+
+esp_err_t espnow_send_script(const char *script, char *result,
+                              size_t result_size, int timeout_ms)
+{
+    if (!s_initialized) return ESP_ERR_INVALID_STATE;
+    if (!script || !result || result_size == 0) return ESP_ERR_INVALID_ARG;
+
+    if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    /* Set up result buffer */
+    s_result_buf = result;
+    s_result_size = result_size;
+    s_result_len = 0;
+    s_result_total = 0;
+    s_result_seq = 0;
+    result[0] = '\0';
+
+    xEventGroupClearBits(s_event_group, BIT_RESULT_DONE);
+
+    size_t script_len = strlen(script);
+    size_t offset = 0;
+    uint16_t seq = 0;
+    uint8_t pkt[ESPNOW_MAX_PAYLOAD];
+    esp_err_t err = ESP_OK;
+
+    while (offset < script_len) {
+        size_t remaining = script_len - offset;
+        size_t chunk = (remaining > ESPNOW_CHUNK_DATA) ? ESPNOW_CHUNK_DATA : remaining;
+        bool is_last = (offset + chunk >= script_len);
+
+        uint8_t type;
+        if (seq == 0) {
+            type = ESPNOW_MSG_SCRIPT_START;
+        } else if (is_last) {
+            type = ESPNOW_MSG_SCRIPT_END;
+        } else {
+            type = ESPNOW_MSG_SCRIPT_CHUNK;
+        }
+
+        build_header(pkt, type, seq, (seq == 0) ? (uint32_t)script_len : 0);
+        memcpy(pkt + ESPNOW_HEADER_SIZE, script + offset, chunk);
+
+        err = send_chunk_and_wait(pkt, ESPNOW_HEADER_SIZE + chunk);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Send chunk %u failed", seq);
+            break;
+        }
+
+        offset += chunk;
+        seq++;
+
+        /* Small delay between chunks to avoid overwhelming receiver */
+        if (!is_last) {
+            vTaskDelay(pdMS_TO_TICKS(5));
+        }
+    }
+
+    if (err != ESP_OK) {
+        s_result_buf = NULL;
+        xSemaphoreGive(s_mutex);
+        return err;
+    }
+
+    /* Wait for result from Board B */
+    ESP_LOGI(TAG, "Script sent (%u bytes), waiting for result...", (unsigned)script_len);
+
+    EventBits_t bits = xEventGroupWaitBits(s_event_group, BIT_RESULT_DONE,
+                                            pdTRUE, pdFALSE,
+                                            pdMS_TO_TICKS(timeout_ms));
+
+    s_result_buf = NULL;
+    xSemaphoreGive(s_mutex);
+
+    if (!(bits & BIT_RESULT_DONE)) {
+        snprintf(result, result_size, "Error: Board B execution timed out after %d ms", timeout_ms);
+        return ESP_ERR_TIMEOUT;
+    }
+
+    return ESP_OK;
+}

--- a/main/espnow/espnow_manager.h
+++ b/main/espnow/espnow_manager.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* ESP-NOW message types */
+#define ESPNOW_MSG_SCRIPT_START   0x01
+#define ESPNOW_MSG_SCRIPT_CHUNK   0x02
+#define ESPNOW_MSG_SCRIPT_END     0x03
+#define ESPNOW_MSG_RESULT_START   0x11
+#define ESPNOW_MSG_RESULT_CHUNK   0x12
+#define ESPNOW_MSG_RESULT_END     0x13
+
+/**
+ * Initialize ESP-NOW and add the peer (Board B).
+ * Must be called after WiFi is started.
+ * Reads peer MAC from NVS; returns ESP_ERR_NOT_FOUND if not configured.
+ */
+esp_err_t espnow_manager_init(void);
+
+/**
+ * Send a Python script to Board B and wait for the execution result.
+ *
+ * @param script       Null-terminated Python source code
+ * @param result       Buffer to receive execution output
+ * @param result_size  Size of result buffer
+ * @param timeout_ms   Max wait time in milliseconds
+ * @return ESP_OK on success
+ */
+esp_err_t espnow_send_script(const char *script, char *result,
+                              size_t result_size, int timeout_ms);
+
+/**
+ * Check if ESP-NOW is initialized and peer is configured.
+ */
+bool espnow_is_ready(void);

--- a/main/mimi.c
+++ b/main/mimi.c
@@ -25,6 +25,7 @@
 #include "cron/cron_service.h"
 #include "heartbeat/heartbeat.h"
 #include "skills/skill_loader.h"
+#include "espnow/espnow_manager.h"
 
 static const char *TAG = "mimi";
 
@@ -147,6 +148,16 @@ void app_main(void)
         ESP_LOGI(TAG, "Waiting for WiFi connection...");
         if (wifi_manager_wait_connected(30000) == ESP_OK) {
             ESP_LOGI(TAG, "WiFi connected: %s", wifi_manager_get_ip());
+
+            /* Initialize ESP-NOW (optional, non-fatal if peer not configured) */
+            esp_err_t espnow_err = espnow_manager_init();
+            if (espnow_err == ESP_OK) {
+                ESP_LOGI(TAG, "ESP-NOW ready (Board B paired)");
+            } else if (espnow_err == ESP_ERR_NOT_FOUND) {
+                ESP_LOGI(TAG, "ESP-NOW peer not set (use 'set_espnow_peer' to configure)");
+            } else {
+                ESP_LOGW(TAG, "ESP-NOW init failed: %s", esp_err_to_name(espnow_err));
+            }
 
             /* Outbound dispatch task should start first to avoid dropping early replies. */
             ESP_ERROR_CHECK((xTaskCreatePinnedToCore(

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -137,6 +137,14 @@
 #define MIMI_NVS_PROXY               "proxy_config"
 #define MIMI_NVS_SEARCH              "search_config"
 
+/* ESP-NOW (Dual-board) */
+#define MIMI_ESPNOW_CHANNEL          0        /* 0 = use current WiFi channel */
+#define MIMI_ESPNOW_TIMEOUT_MS       15000
+#define MIMI_ESPNOW_RESULT_BUF       4096
+
+/* NVS Namespaces (continued) */
+#define MIMI_NVS_ESPNOW              "espnow_config"
+
 /* NVS Keys */
 #define MIMI_NVS_KEY_SSID            "ssid"
 #define MIMI_NVS_KEY_PASS            "password"
@@ -149,3 +157,4 @@
 #define MIMI_NVS_KEY_PROVIDER        "provider"
 #define MIMI_NVS_KEY_PROXY_HOST      "host"
 #define MIMI_NVS_KEY_PROXY_PORT      "port"
+#define MIMI_NVS_KEY_PEER_MAC        "peer_mac"

--- a/main/tools/tool_registry.c
+++ b/main/tools/tool_registry.c
@@ -4,6 +4,7 @@
 #include "tools/tool_get_time.h"
 #include "tools/tool_files.h"
 #include "tools/tool_cron.h"
+#include "tools/tool_run_python.h"
 
 #include <string.h>
 #include "esp_log.h"
@@ -175,6 +176,20 @@ esp_err_t tool_registry_init(void)
         .execute = tool_cron_remove_execute,
     };
     register_tool(&cr);
+
+    /* Register run_python */
+    mimi_tool_t rp = {
+        .name = "run_python",
+        .description = "Execute a Python script on Board B (remote ESP32 running MicroPython) via ESP-NOW. "
+                       "Returns stdout output and any exceptions. Board B must be powered on and paired.",
+        .input_schema_json =
+            "{\"type\":\"object\","
+            "\"properties\":{\"code\":{\"type\":\"string\",\"description\":\"Python source code to execute\"},"
+            "\"timeout_ms\":{\"type\":\"integer\",\"description\":\"Max execution time in ms (default 15000)\"}},"
+            "\"required\":[\"code\"]}",
+        .execute = tool_run_python_execute,
+    };
+    register_tool(&rp);
 
     build_tools_json();
 

--- a/main/tools/tool_run_python.c
+++ b/main/tools/tool_run_python.c
@@ -1,0 +1,54 @@
+#include "tool_run_python.h"
+#include "mimi_config.h"
+#include "espnow/espnow_manager.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include "esp_log.h"
+#include "cJSON.h"
+
+static const char *TAG = "tool_python";
+
+esp_err_t tool_run_python_execute(const char *input_json, char *output, size_t output_size)
+{
+    if (!espnow_is_ready()) {
+        snprintf(output, output_size,
+                 "Error: ESP-NOW not initialized. Configure peer with 'set espnow_peer XX:XX:XX:XX:XX:XX'");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    cJSON *root = cJSON_Parse(input_json);
+    if (!root) {
+        snprintf(output, output_size, "Error: invalid JSON input");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    cJSON *code = cJSON_GetObjectItem(root, "code");
+    if (!cJSON_IsString(code) || code->valuestring[0] == '\0') {
+        snprintf(output, output_size, "Error: 'code' parameter required");
+        cJSON_Delete(root);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    int timeout = MIMI_ESPNOW_TIMEOUT_MS;
+    cJSON *tm = cJSON_GetObjectItem(root, "timeout_ms");
+    if (cJSON_IsNumber(tm) && tm->valueint > 0) {
+        timeout = tm->valueint;
+    }
+
+    ESP_LOGI(TAG, "Sending Python script (%u bytes) to Board B",
+             (unsigned)strlen(code->valuestring));
+
+    esp_err_t err = espnow_send_script(code->valuestring, output, output_size, timeout);
+
+    cJSON_Delete(root);
+
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Script execution failed: %s", esp_err_to_name(err));
+    } else {
+        ESP_LOGI(TAG, "Script result: %.80s%s", output,
+                 strlen(output) > 80 ? "..." : "");
+    }
+
+    return err;
+}

--- a/main/tools/tool_run_python.h
+++ b/main/tools/tool_run_python.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "esp_err.h"
+#include <stddef.h>
+
+/**
+ * Execute run_python tool.
+ * Sends a Python script to Board B via ESP-NOW and returns the execution result.
+ */
+esp_err_t tool_run_python_execute(const char *input_json, char *output, size_t output_size);


### PR DESCRIPTION
Board A (MimiClaw) sends Python scripts via ESP-NOW to Board B (MicroPython executor) and receives execution results. This enables extensible skill execution without being limited by ESP32's C-only firmware environment.

- Add espnow_manager module with chunked send/receive protocol
- Add run_python tool for LLM agent to execute Python on Board B
- Add set_espnow_peer CLI command and config_show/reset support
- Add executor/ directory with MicroPython boot.py and main.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a setup and operational guide for the Board B MicroPython executor, including pairing and usage steps.

* **New Features**
  * CLI option to configure the wireless peer MAC for board-to-board pairing.
  * Remote Python execution on Board B over ESP-NOW with chunked transfer and automatic result return.
  * Device prints its MAC and ready-to-pair instruction on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->