### PR TITLE
Add configurable OpenAI-compatible base URL support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# AGENTS.md
+
+## Purpose
+
+This repository uses a markdown-first layered memory system. Chat context is
+not the durable source of truth.
+
+## Read Order
+
+Before starting substantial work, read in this order:
+
+1. `AGENTS.md`
+2. `resume-queue.md`
+3. `MEMORY.md`
+4. The most relevant fact docs for the task
+5. The latest relevant file under `memory/`
+6. `knowledge/` only when detailed evidence is needed
+
+## Fact Docs
+
+Default fact docs in this repo:
+
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `main/idf_component.yml`
+- `sdkconfig.defaults.esp32s3`
+- `partitions.csv`
+- implementation files directly related to the task
+
+## Layer Rules
+
+- `AGENTS.md`: behavior rules, read order, resume / handoff protocol
+- `resume-queue.md`: current pending work, default resume target, next concrete step
+- `MEMORY.md`: stable repo-level working memory only
+- `memory/YYYY-MM-DD.md`: daily working memory and checkpoints
+- fact docs: topic-specific facts and baselines
+- `decision-log.md`: append-only major engineering decisions
+- `knowledge/`: evidence, experiments, logs, failure samples
+
+Do not duplicate the same fact across multiple layers when one file is already
+the stronger source of truth.
+
+## Session Boundary
+
+If the user says `开口`, or asks to continue from a prior session:
+
+1. Read the files in `Read Order`
+2. Resume from `resume-queue.md`
+3. Only read deeper evidence if the current task requires it
+
+If the user says `收口`, treat it as a handoff checkpoint:
+
+1. Update `resume-queue.md`
+2. Update today's `memory/YYYY-MM-DD.md` if needed
+3. Promote stable conclusions to `MEMORY.md` when justified
+4. Append to `decision-log.md` if a real decision was made
+
+These two commands are not casual wording in this repo; they are the explicit
+session control protocol.
+
+## Checkpoint Rule
+
+At any meaningful checkpoint:
+
+1. Update `resume-queue.md`
+2. Update today's daily memory if there is useful short-term carry-over
+3. Promote only stable, cross-session conclusions to `MEMORY.md`
+4. Keep detailed evidence out of the default resume path
+
+## High-Value Capture Rule
+
+Actively identify reusable high-value content during normal work and persist it
+locally instead of leaving it only in chat context.
+
+Treat the following as high-value by default:
+
+- explicit engineering decisions
+- repeated debugging conclusions
+- stable cross-session reminders
+- important constraints, boundaries, and interface expectations
+- environment baselines and platform facts
+- common failure modes and rollback paths
+- conclusions that materially reduce future re-discovery cost
+
+When such content appears:
+
+1. choose the narrowest correct layer
+2. write it once to the strongest source of truth
+3. update `resume-queue.md` if it changes how the next session should resume
+4. append to `decision-log.md` if it is a real decision
+5. use `memory/YYYY-MM-DD.md` first when the conclusion is still fresh but not
+   yet stable
+
+Do not wait until the end of a long task to record reusable conclusions if they
+are already clear.
+
+## Interaction Contract
+
+- Treat the markdown memory system itself as part of the durable collaboration
+  surface, not just the technical project state.
+- If the user asks to "沉淀" interaction rules, reopen / close protocol, or
+  cross-session collaboration expectations, write them into the local memory
+  layers instead of leaving them only in chat history.
+- Prefer storing protocol in `AGENTS.md`, stable collaboration expectations in
+  `MEMORY.md`, and session-specific interaction notes in `memory/YYYY-MM-DD.md`.
+- When relevant work depends on verified context from sibling repositories or
+  prior hardware bring-up, import the reusable conclusions into this repo's
+  memory layers rather than assuming the next session will remember them.
+- If the user switches from a sibling workspace such as `esp32` into this repo
+  and wants to continue work, the handoff should feel seamless: recover the
+  imported context from local memory first and do not make the user restate the
+  same hardware / workflow background unless new evidence conflicts with it.
+
+## Risk Boundary
+
+- Do not treat chat history as durable memory
+- Do not turn `MEMORY.md` into a dumping ground
+- Do not put pending queue items into `MEMORY.md`
+- Do not use `knowledge/` as the default resume entrypoint
+- Prefer the narrowest valid source of truth

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,72 @@
+# MEMORY.md
+
+## Stable Repo-Level Memory
+
+- This repo should use markdown files as the durable collaboration control
+  plane; do not rely on chat context alone.
+- Default recovery entrypoint is `resume-queue.md`, not `MEMORY.md`.
+- Stable user / agent collaboration reminder:
+  the user expects durable context, protocol, and important interaction
+  agreements to be written into this repo's local memory files instead of being
+  left only in chat history.
+- Stable session-control reminder:
+  `开口` means resume from the repo's local handoff state, and `收口` means
+  produce a real local checkpoint / handoff update, not just a conversational
+  summary.
+- Stable cross-workspace collaboration reminder:
+  when the user moves from `/Users/lize/workspace/esp32` into
+  `/Users/lize/workspace/mimiclaw` to continue related work, the transition is
+  expected to be seamless; this repo should already contain enough imported
+  memory to resume without forcing the user to restate prior board context.
+- For repo facts, prefer:
+  - `README.md` for workflow and operator-facing setup
+  - `docs/ARCHITECTURE.md` for module map and runtime architecture
+  - `main/idf_component.yml` for required `ESP-IDF` range
+  - `sdkconfig.defaults.esp32s3` and `partitions.csv` for platform baseline
+  - implementation files for actual behavior
+- For collaboration facts, prefer:
+  - `AGENTS.md` for protocol and memory-layer rules
+  - `resume-queue.md` for the next concrete resume point
+  - `MEMORY.md` for stable collaboration reminders and cross-session
+    constraints
+  - `memory/YYYY-MM-DD.md` for fresh interaction context that is not yet stable
+- When evaluating hardware fit, separate:
+  - board hardware compatibility
+  - host build environment compatibility
+- Current important compatibility reminder:
+  this repo requires `ESP-IDF >=5.5.0,<5.6.0`; do not assume an older working
+  `ESP-IDF` from another repository is acceptable here.
+- Verified host environment for this repo on this machine:
+  `ESP-IDF v5.5.2` at `/Users/lize/.espressif/esp-idf-v5.5.2` with Python env
+  `/Users/lize/.espressif/python_env/idf5.5_py3.14_env`.
+- Verified board baseline for the local `ATK-DNESP32S3`:
+  `mimiclaw` builds, flashes to `/dev/cu.usbserial-10` at `460800`, boots, and
+  exposes a working serial CLI prompt at `115200`.
+- Stable hardware profile for the local `ATK-DNESP32S3` board:
+  `ESP32-S3R8`, `16MB` flash, `8MB` PSRAM, `ST7789V 320x240` SPI LCD,
+  shared-SPI `TF / microSD`, `OV2640` camera path on the dedicated camera
+  peripheral, and onboard audio hardware.
+- Previously verified board bring-up facts from the dedicated hardware repo:
+  - the controllable onboard LED is the red status LED on `GPIO1`, active-low
+  - LCD bring-up required the `XL9555` I/O expander at `0x20` to explicitly
+    drive LCD power / backlight and reset; assuming LCD control pins were `NC`
+    caused a black screen even when firmware logs looked healthy
+  - the LCD and TF card share the same SPI bus; TF smoke passed only after a
+    card was inserted before boot or reset
+  - `460800` is the known-good flash baud on this board; `921600` previously
+    proved unstable
+- For `mimiclaw` specifically, treat LED / LCD / TF board bring-up as already
+  de-risked background knowledge, not as the default suspected cause of core
+  boot or CLI failures unless new evidence points there.
+- Stable interaction preference observed in this repo:
+  when hardware knowledge, workflow protocol, or collaboration expectations
+  become relevant to `mimiclaw`, persist them locally in this repo instead of
+  expecting the next session to recover them from another repository or from
+  chat alone.
+- Stable runtime capability reminder:
+  this repo now supports an NVS-backed/customizable `LLM base URL` via the CLI
+  command `set_base_url`; this is required for OpenAI-compatible providers that
+  are not `api.openai.com`.
+- Stable local validation reminder:
+  on the local `ATK-DNESP32S3`, the first fully verified real channel path is
+  `Feishu` using an OpenAI-compatible backend with custom `base_url` support.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Edit `main/mimi_secrets.h`:
 #define MIMI_SECRET_TG_TOKEN        "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
 #define MIMI_SECRET_API_KEY         "sk-ant-api03-xxxxx"
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic" or "openai"
+#define MIMI_SECRET_LLM_BASE_URL    ""              // optional: OpenAI-compatible base URL
 #define MIMI_SECRET_SEARCH_KEY      ""              // optional: Brave Search API key
 #define MIMI_SECRET_TAVILY_KEY      ""              // optional: Tavily API key (preferred)
 #define MIMI_SECRET_PROXY_HOST      ""              // optional: e.g. "10.0.0.1"
@@ -166,11 +167,12 @@ Connect via serial to configure or debug. **Config commands** let you change set
 **Runtime config** (saved to NVS, overrides build-time defaults):
 
 ```
-mimi> wifi_set MySSID MyPassword   # change WiFi network
+mimi> set_wifi MySSID MyPassword   # change WiFi network
 mimi> set_tg_token 123456:ABC...   # change Telegram bot token
 mimi> set_api_key sk-ant-api03-... # change API key (Anthropic or OpenAI)
 mimi> set_model_provider openai    # switch provider (anthropic|openai)
 mimi> set_model gpt-4o             # change LLM model
+mimi> set_base_url https://coding.dashscope.aliyuncs.com/v1  # optional: OpenAI-compatible base URL
 mimi> set_proxy 127.0.0.1 7897  # set HTTP proxy
 mimi> clear_proxy                  # remove proxy
 mimi> set_search_key BSA...        # set Brave Search API key

--- a/decision-log.md
+++ b/decision-log.md
@@ -1,0 +1,212 @@
+# Decision Log
+
+## 2026-03-08 - Adopt markdown-first layered memory system
+
+Decision:
+
+- Use a local markdown-first memory system for cross-session continuity in this
+  repo.
+
+Why:
+
+- Chat context is not durable
+- The repo did not yet have a structured resume / memory layer
+- The work benefits from separating rules, pending queue, stable memory, daily
+  memory, fact docs, and decisions
+
+Consequences:
+
+- `AGENTS.md` is the control plane for read order and session boundaries
+- `resume-queue.md` is the default resume entrypoint
+- `MEMORY.md` stores only stable repo-level reminders
+- `memory/YYYY-MM-DD.md` stores daily working memory
+
+Rollback:
+
+- If this structure proves too heavy for the repo, keep `AGENTS.md`,
+  `resume-queue.md`, and `MEMORY.md` as the minimum durable core
+
+## 2026-03-08 - Choose ESP-IDF v5.5.2 for the next validation cycle
+
+Decision:
+
+- Use `ESP-IDF v5.5.2` as the next version for build and hardware validation in
+  this repo.
+
+Five axioms used:
+
+1. explicit upstream compatibility constraints outrank local convenience
+2. within an allowed minor line, prefer the latest stable bugfix release
+3. do not widen the version interval before the baseline build is proven
+4. do not use a pre-release when a matching stable release exists
+5. choose the path with the cheapest rollback and the clearest success criteria
+
+Why:
+
+- `main/idf_component.yml` explicitly requires `>=5.5.0,<5.6.0`
+- `v5.5.2` is the latest stable bugfix release in the allowed `5.5.x` line
+- local visible checkouts are both `v5.1.2`, which are outside the repo's
+  allowed range
+- `v6.0-beta1` exists but is pre-release and adds unnecessary migration risk
+  before first baseline validation
+
+Consequences:
+
+- next environment work should target `v5.5.2`, not `v5.4.x`, `v5.1.x`, or
+  `v6.0-beta1`
+- any build failure after moving to `v5.5.2` should be treated as a project or
+  integration issue, not as an expected version mismatch
+
+Rollback:
+
+- if `v5.5.2` exposes a concrete blocker specific to this repo or board, stay
+  within the allowed `5.5.x` line first; only reconsider the minor version
+  boundary after evidence exists
+
+## 2026-03-08 - Reuse the existing ESP-IDF v5.5.2 install and configure on-device first
+
+Decision:
+
+- Reuse the existing local `ESP-IDF v5.5.2` install at
+  `/Users/lize/.espressif/esp-idf-v5.5.2`, keep the already flashed image on
+  the board, and do the first integration validation through the serial CLI
+  rather than creating build-time secrets first.
+
+Why:
+
+- the existing `v5.5.2` checkout and Python environment were already complete
+  and worked immediately for build + flash
+- the board already booted successfully into `MimiClaw` and exposed the `mimi>`
+  CLI prompt
+- runtime configuration through CLI is the fastest path to validate Wi-Fi and
+  the first channel without adding another rebuild cycle
+
+Consequences:
+
+- next work should start from the flashed firmware already on
+  `/dev/cu.usbserial-10`
+- configure Wi-Fi, channel credentials, and API key over serial first
+- only create `main/mimi_secrets.h` later if persistent build-time defaults are
+  actually desired
+
+Rollback:
+
+- if CLI-driven runtime configuration proves insufficient or inconvenient,
+  create `main/mimi_secrets.h`, rebuild, and reflash using the same validated
+  `ESP-IDF v5.5.2` environment
+
+## 2026-03-08 - Persist the collaboration protocol itself in repository memory
+
+Decision:
+
+- Treat the agent-layer collaboration protocol as durable repository context and
+  persist it locally under `AGENTS.md` / `MEMORY.md`, not only as chat
+  convention.
+
+Why:
+
+- the user explicitly uses `开口` / `收口` as session control commands
+- the user explicitly wants agent interaction rules and memory behavior to live
+  under `mimiclaw`
+- this reduces re-discovery cost and keeps cross-session collaboration
+  consistent
+
+Consequences:
+
+- reopen / close behavior should be recoverable from local files alone
+- stable interaction expectations belong in the same memory system as technical
+  context
+- when future interaction conventions become durable, store them locally rather
+  than leaving them implicit
+
+Rollback:
+
+- if this proves too noisy, keep only the minimal explicit protocol in
+  `AGENTS.md` and trim non-essential collaboration notes from `MEMORY.md`
+
+## 2026-03-08 - Optimize for seamless switching from esp32 into mimiclaw
+
+Decision:
+
+- Treat switching from `/Users/lize/workspace/esp32` into this repo as a
+  seamless continuation path, not as a fresh cold start.
+
+Why:
+
+- the current `mimiclaw` work directly depends on verified board and workflow
+  context established in the sibling `esp32` workspace
+- the user explicitly wants cross-workspace continuation without repeated
+  re-briefing
+
+Consequences:
+
+- imported board knowledge and collaboration protocol must be sufficient for
+  fast recovery inside this repo
+- when resuming here after work in `esp32`, read local memory first and proceed
+  from the stored handoff instead of asking the user to restate background
+
+Rollback:
+
+- if the imported context becomes stale or misleading, keep the seamless-switch
+  goal but update the local memory with corrected facts rather than abandoning
+  the approach
+
+## 2026-03-08 - Add runtime-configurable LLM base URL support for OpenAI-compatible providers
+
+Decision:
+
+- Add an NVS-backed/runtime-configurable `LLM base URL` to the firmware and
+  expose it through the serial CLI as `set_base_url`.
+
+Why:
+
+- the existing implementation hard-coded `api.openai.com`, which blocked use of
+  OpenAI-compatible providers such as DashScope
+- the current validation target needed `https://coding.dashscope.aliyuncs.com/v1`
+  with provider `openai` and model `qwen3.5-plus`
+- runtime configuration keeps the operator path consistent with the existing
+  Wi-Fi / channel / model / API-key workflow
+
+Consequences:
+
+- `llm_proxy` now persists and loads `base_url` from NVS
+- `config_show` reports the configured `Base URL`
+- OpenAI-compatible base URLs ending in `/v1` are normalized to
+  `/v1/chat/completions`
+- the proxy code no longer assumes `api.openai.com`; it parses host / path from
+  the configured URL
+- the board can now validate OpenAI-compatible providers without creating
+  `main/mimi_secrets.h`
+
+Rollback:
+
+- if the custom URL layer proves unstable, clear the NVS key and fall back to
+  the provider defaults; if necessary, remove the `set_base_url` path and
+  return to fixed upstream endpoints
+
+## 2026-03-08 - Use Feishu as the first real validated channel
+
+Decision:
+
+- Treat `Feishu` as the first successfully validated real channel path for the
+  local board, ahead of Telegram.
+
+Why:
+
+- the user provided Feishu credentials first
+- the board successfully established Feishu WebSocket connectivity
+- the user confirmed that real Feishu in-chat messaging works end-to-end after
+  the OpenAI-compatible LLM path was configured
+
+Consequences:
+
+- subsequent work can start from a known-good Feishu baseline instead of
+  treating channel validation as still blocked
+- the next engineering focus should shift from first-message bring-up to
+  documentation cleanup, reproducibility, or additional channel validation
+
+Rollback:
+
+- if later evidence shows the Feishu path is unstable or environment-specific,
+  keep the implementation but downgrade this from a baseline assumption until
+  reliability is re-established

--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -141,6 +141,12 @@ static struct {
     struct arg_end *end;
 } model_args;
 
+/* --- set_base_url command --- */
+static struct {
+    struct arg_str *url;
+    struct arg_end *end;
+} base_url_args;
+
 static int cmd_set_model(int argc, char **argv)
 {
     int nerrors = arg_parse(argc, argv, (void **)&model_args);
@@ -150,6 +156,18 @@ static int cmd_set_model(int argc, char **argv)
     }
     llm_set_model(model_args.model->sval[0]);
     printf("Model set.\n");
+    return 0;
+}
+
+static int cmd_set_base_url(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&base_url_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, base_url_args.end, argv[0]);
+        return 1;
+    }
+    llm_set_base_url(base_url_args.url->sval[0]);
+    printf("Base URL saved.\n");
     return 0;
 }
 
@@ -537,6 +555,7 @@ static int cmd_config_show(int argc, char **argv)
     print_config("API Key",    MIMI_NVS_LLM,    MIMI_NVS_KEY_API_KEY,  MIMI_SECRET_API_KEY,    true);
     print_config("Model",      MIMI_NVS_LLM,    MIMI_NVS_KEY_MODEL,    MIMI_SECRET_MODEL,      false);
     print_config("Provider",   MIMI_NVS_LLM,    MIMI_NVS_KEY_PROVIDER, MIMI_SECRET_MODEL_PROVIDER, false);
+    print_config("Base URL",   MIMI_NVS_LLM,    MIMI_NVS_KEY_BASE_URL, MIMI_SECRET_LLM_BASE_URL, false);
     print_config("Proxy Host", MIMI_NVS_PROXY,  MIMI_NVS_KEY_PROXY_HOST, MIMI_SECRET_PROXY_HOST, false);
     print_config("Proxy Port", MIMI_NVS_PROXY,  MIMI_NVS_KEY_PROXY_PORT, MIMI_SECRET_PROXY_PORT, false);
     print_config("Search Key", MIMI_NVS_SEARCH, MIMI_NVS_KEY_API_KEY,  MIMI_SECRET_SEARCH_KEY, true);
@@ -859,6 +878,17 @@ esp_err_t serial_cli_init(void)
         .argtable = &model_args,
     };
     esp_console_cmd_register(&model_cmd);
+
+    /* set_base_url */
+    base_url_args.url = arg_str1(NULL, NULL, "<url>", "LLM API base URL");
+    base_url_args.end = arg_end(1);
+    esp_console_cmd_t base_url_cmd = {
+        .command = "set_base_url",
+        .help = "Set LLM API base URL (e.g. set_base_url https://coding.dashscope.aliyuncs.com/v1)",
+        .func = &cmd_set_base_url,
+        .argtable = &base_url_args,
+    };
+    esp_console_cmd_register(&base_url_cmd);
 
     /* set_model_provider */
     provider_args.provider = arg_str1(NULL, NULL, "<provider>", "Model provider (anthropic|openai)");

--- a/main/llm/llm_proxy.c
+++ b/main/llm/llm_proxy.c
@@ -13,14 +13,19 @@
 
 static const char *TAG = "llm";
 
-#define LLM_API_KEY_MAX_LEN 320
-#define LLM_MODEL_MAX_LEN   64
+#define LLM_API_KEY_MAX_LEN  320
+#define LLM_MODEL_MAX_LEN    64
+#define LLM_BASE_URL_MAX_LEN 192
+#define LLM_URL_MAX_LEN      224
+#define LLM_HOST_MAX_LEN     96
+#define LLM_PATH_MAX_LEN     160
 #define LLM_DUMP_MAX_BYTES   (16 * 1024)
 #define LLM_DUMP_CHUNK_BYTES 320
 
 static char s_api_key[LLM_API_KEY_MAX_LEN] = {0};
 static char s_model[LLM_MODEL_MAX_LEN] = MIMI_LLM_DEFAULT_MODEL;
 static char s_provider[16] = MIMI_LLM_PROVIDER_DEFAULT;
+static char s_base_url[LLM_BASE_URL_MAX_LEN] = {0};
 
 static void llm_log_payload(const char *label, const char *payload)
 {
@@ -187,19 +192,97 @@ static bool provider_is_openai(void)
     return strcmp(s_provider, "openai") == 0;
 }
 
-static const char *llm_api_url(void)
+static size_t trim_trailing_slashes(const char *src, size_t len)
+{
+    while (len > 0 && src[len - 1] == '/') {
+        len--;
+    }
+    return len;
+}
+
+static bool str_ends_with_n(const char *src, size_t src_len, const char *suffix)
+{
+    size_t suffix_len = strlen(suffix);
+    if (src_len < suffix_len) return false;
+    return strncmp(src + src_len - suffix_len, suffix, suffix_len) == 0;
+}
+
+static const char *llm_default_api_url(void)
 {
     return provider_is_openai() ? MIMI_OPENAI_API_URL : MIMI_LLM_API_URL;
 }
 
-static const char *llm_api_host(void)
+static bool llm_build_api_url(char *out, size_t out_size)
 {
-    return provider_is_openai() ? "api.openai.com" : "api.anthropic.com";
+    const char *base = s_base_url[0] ? s_base_url : llm_default_api_url();
+    size_t base_len = trim_trailing_slashes(base, strlen(base));
+
+    if (base_len == 0 || base_len >= out_size) {
+        return false;
+    }
+
+    if (provider_is_openai() &&
+        !str_ends_with_n(base, base_len, "/chat/completions")) {
+        int n = snprintf(out, out_size, "%.*s/chat/completions", (int)base_len, base);
+        return n > 0 && (size_t)n < out_size;
+    }
+
+    memcpy(out, base, base_len);
+    out[base_len] = '\0';
+    return true;
 }
 
-static const char *llm_api_path(void)
+static bool llm_parse_api_target(const char *url,
+                                 char *host,
+                                 size_t host_size,
+                                 int *port,
+                                 char *path,
+                                 size_t path_size)
 {
-    return provider_is_openai() ? "/v1/chat/completions" : "/v1/messages";
+    const char *scheme = strstr(url, "://");
+    const char *host_start = scheme ? scheme + 3 : url;
+    const char *path_start = strchr(host_start, '/');
+    const char *host_end = path_start ? path_start : host_start + strlen(host_start);
+    const char *port_sep = NULL;
+
+    for (const char *p = host_start; p < host_end; ++p) {
+        if (*p == ':') {
+            port_sep = p;
+            break;
+        }
+    }
+
+    size_t host_len = (size_t)((port_sep ? port_sep : host_end) - host_start);
+    if (host_len == 0 || host_len >= host_size) {
+        return false;
+    }
+
+    memcpy(host, host_start, host_len);
+    host[host_len] = '\0';
+
+    *port = 443;
+    if (port_sep) {
+        *port = atoi(port_sep + 1);
+        if (*port <= 0) {
+            return false;
+        }
+    }
+
+    if (path_start) {
+        size_t path_len = strlen(path_start);
+        if (path_len >= path_size) {
+            return false;
+        }
+        memcpy(path, path_start, path_len + 1);
+    } else {
+        if (path_size < 2) {
+            return false;
+        }
+        path[0] = '/';
+        path[1] = '\0';
+    }
+
+    return true;
 }
 
 /* ── Init ─────────────────────────────────────────────────────── */
@@ -215,6 +298,9 @@ esp_err_t llm_proxy_init(void)
     }
     if (MIMI_SECRET_MODEL_PROVIDER[0] != '\0') {
         safe_copy(s_provider, sizeof(s_provider), MIMI_SECRET_MODEL_PROVIDER);
+    }
+    if (MIMI_SECRET_LLM_BASE_URL[0] != '\0') {
+        safe_copy(s_base_url, sizeof(s_base_url), MIMI_SECRET_LLM_BASE_URL);
     }
 
     /* NVS overrides take highest priority (set via CLI) */
@@ -235,6 +321,11 @@ esp_err_t llm_proxy_init(void)
         if (nvs_get_str(nvs, MIMI_NVS_KEY_PROVIDER, provider_tmp, &len) == ESP_OK && provider_tmp[0]) {
             safe_copy(s_provider, sizeof(s_provider), provider_tmp);
         }
+        char base_url_tmp[LLM_BASE_URL_MAX_LEN] = {0};
+        len = sizeof(base_url_tmp);
+        if (nvs_get_str(nvs, MIMI_NVS_KEY_BASE_URL, base_url_tmp, &len) == ESP_OK && base_url_tmp[0]) {
+            safe_copy(s_base_url, sizeof(s_base_url), base_url_tmp);
+        }
         nvs_close(nvs);
     }
 
@@ -250,8 +341,14 @@ esp_err_t llm_proxy_init(void)
 
 static esp_err_t llm_http_direct(const char *post_data, resp_buf_t *rb, int *out_status)
 {
+    char api_url[LLM_URL_MAX_LEN];
+    if (!llm_build_api_url(api_url, sizeof(api_url))) {
+        ESP_LOGE(TAG, "Invalid LLM API URL configuration");
+        return ESP_ERR_INVALID_ARG;
+    }
+
     esp_http_client_config_t config = {
-        .url = llm_api_url(),
+        .url = api_url,
         .event_handler = http_event_handler,
         .user_data = rb,
         .timeout_ms = 120 * 1000,
@@ -287,7 +384,18 @@ static esp_err_t llm_http_direct(const char *post_data, resp_buf_t *rb, int *out
 
 static esp_err_t llm_http_via_proxy(const char *post_data, resp_buf_t *rb, int *out_status)
 {
-    proxy_conn_t *conn = proxy_conn_open(llm_api_host(), 443, 30000);
+    char api_url[LLM_URL_MAX_LEN];
+    char api_host[LLM_HOST_MAX_LEN];
+    char api_path[LLM_PATH_MAX_LEN];
+    int api_port = 443;
+
+    if (!llm_build_api_url(api_url, sizeof(api_url)) ||
+        !llm_parse_api_target(api_url, api_host, sizeof(api_host), &api_port, api_path, sizeof(api_path))) {
+        ESP_LOGE(TAG, "Invalid LLM API URL configuration");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    proxy_conn_t *conn = proxy_conn_open(api_host, api_port, 30000);
     if (!conn) return ESP_ERR_HTTP_CONNECT;
 
     int body_len = strlen(post_data);
@@ -301,7 +409,7 @@ static esp_err_t llm_http_via_proxy(const char *post_data, resp_buf_t *rb, int *
             "Authorization: Bearer %s\r\n"
             "Content-Length: %d\r\n"
             "Connection: close\r\n\r\n",
-            llm_api_path(), llm_api_host(), s_api_key, body_len);
+            api_path, api_host, s_api_key, body_len);
     } else {
         hlen = snprintf(header, sizeof(header),
             "POST %s HTTP/1.1\r\n"
@@ -311,7 +419,7 @@ static esp_err_t llm_http_via_proxy(const char *post_data, resp_buf_t *rb, int *
             "anthropic-version: %s\r\n"
             "Content-Length: %d\r\n"
             "Connection: close\r\n\r\n",
-            llm_api_path(), llm_api_host(), s_api_key, MIMI_LLM_API_VERSION, body_len);
+            api_path, api_host, s_api_key, MIMI_LLM_API_VERSION, body_len);
     }
 
     if (proxy_conn_write(conn, header, hlen) < 0 ||
@@ -807,5 +915,18 @@ esp_err_t llm_set_provider(const char *provider)
 
     safe_copy(s_provider, sizeof(s_provider), provider);
     ESP_LOGI(TAG, "Provider set to: %s", s_provider);
+    return ESP_OK;
+}
+
+esp_err_t llm_set_base_url(const char *base_url)
+{
+    nvs_handle_t nvs;
+    ESP_ERROR_CHECK(nvs_open(MIMI_NVS_LLM, NVS_READWRITE, &nvs));
+    ESP_ERROR_CHECK(nvs_set_str(nvs, MIMI_NVS_KEY_BASE_URL, base_url));
+    ESP_ERROR_CHECK(nvs_commit(nvs));
+    nvs_close(nvs);
+
+    safe_copy(s_base_url, sizeof(s_base_url), base_url);
+    ESP_LOGI(TAG, "Base URL set to: %s", s_base_url);
     return ESP_OK;
 }

--- a/main/llm/llm_proxy.h
+++ b/main/llm/llm_proxy.h
@@ -27,6 +27,11 @@ esp_err_t llm_set_provider(const char *provider);
  */
 esp_err_t llm_set_model(const char *model);
 
+/**
+ * Save the LLM base URL to NVS.
+ */
+esp_err_t llm_set_base_url(const char *base_url);
+
 /* ── Tool Use Support ──────────────────────────────────────────── */
 
 typedef struct {

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -25,6 +25,9 @@
 #ifndef MIMI_SECRET_MODEL_PROVIDER
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
 #endif
+#ifndef MIMI_SECRET_LLM_BASE_URL
+#define MIMI_SECRET_LLM_BASE_URL    ""
+#endif
 #ifndef MIMI_SECRET_PROXY_HOST
 #define MIMI_SECRET_PROXY_HOST      ""
 #endif
@@ -147,5 +150,6 @@
 #define MIMI_NVS_KEY_TAVILY_KEY      "tavily_key"
 #define MIMI_NVS_KEY_MODEL           "model"
 #define MIMI_NVS_KEY_PROVIDER        "provider"
+#define MIMI_NVS_KEY_BASE_URL        "base_url"
 #define MIMI_NVS_KEY_PROXY_HOST      "host"
 #define MIMI_NVS_KEY_PROXY_PORT      "port"

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -25,6 +25,7 @@
 #define MIMI_SECRET_API_KEY         ""
 #define MIMI_SECRET_MODEL           ""
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
+#define MIMI_SECRET_LLM_BASE_URL    ""   /* optional: e.g. https://coding.dashscope.aliyuncs.com/v1 */
 
 /* HTTP Proxy (leave empty or set both) */
 #define MIMI_SECRET_PROXY_HOST      ""

--- a/memory/2026-03-08.md
+++ b/memory/2026-03-08.md
@@ -1,0 +1,95 @@
+# 2026-03-08
+
+## Session Notes
+
+- Inspected `mimiclaw` top-level layout and confirmed it is an `ESP-IDF`
+  firmware project for `ESP32-S3`, not a Python / Node app.
+- Read `README.md`, `docs/ARCHITECTURE.md`, `main/mimi.c`,
+  `main/CMakeLists.txt`, `main/idf_component.yml`, and
+  `sdkconfig.defaults.esp32s3`.
+- Confirmed the runtime model is a networked agent firmware with:
+  Wi-Fi, LLM proxy, Telegram, Feishu, WebSocket, serial CLI, SPIFFS memory,
+  tools, cron, and heartbeat subsystems.
+- Confirmed the repo does not appear to depend on display, camera, TF, or audio
+  peripherals for its core path.
+- Compared repo hardware requirements against the local `ATK-DNESP32S3` board:
+  hardware fit looks good on paper because both sides align on `ESP32-S3`,
+  `16MB` flash, and `8MB` PSRAM.
+- Applied a five-axiom decision frame to version selection and chose
+  `ESP-IDF v5.5.2` as the next target:
+  follow the repo's explicit compatibility window, prefer the latest stable
+  patch inside that window, reject older convenient locals, reject `6.0-beta`
+  before baseline validation, and keep rollback simple.
+- Confirmed both currently visible local checkouts,
+  `/Users/lize/esp/esp-idf` and `/Users/lize/esp/esp-idf-shallow`, resolve to
+  `v5.1.2`, which explained why the earlier scan initially looked blocked.
+- Verified the real working environment instead lives at
+  `/Users/lize/.espressif/esp-idf-v5.5.2`, so no fresh `ESP-IDF 5.5.2`
+  installation was needed on this machine.
+
+## Carry-Over
+
+- The already-installed `ESP-IDF v5.5.2` environment was found under
+  `/Users/lize/.espressif/esp-idf-v5.5.2`; the earlier assumption that a new
+  install was required was incorrect.
+- `IDF_DIR=/Users/lize/.espressif/esp-idf-v5.5.2 /bin/bash scripts/build_macos.sh`
+  completed successfully and produced `build/mimiclaw.bin` plus `build/spiffs.bin`.
+- Flash to `/dev/cu.usbserial-10` at `460800` completed successfully.
+- Serial verification confirmed:
+  - `help` works at the `mimi>` prompt
+  - soft restart shows full boot logs under `ESP-IDF v5.5.2`
+  - SPIFFS mounts, skills load, and the app reaches `MimiClaw ready`
+  - warnings are limited to missing runtime credentials, not boot failure
+- Imported the reusable board knowledge from the dedicated DNESP32S3 bring-up
+  work into `mimiclaw` memory:
+  - hardware profile: `ESP32-S3R8`, `16MB` flash, `8MB` PSRAM, LCD + TF +
+    camera + audio board family
+  - red status LED is the controllable LED on `GPIO1`
+  - LCD requires `XL9555` board-control sequencing for power/backlight/reset
+  - TF shares the LCD SPI bus and was already validated on real hardware
+  - `460800` flash and `115200` serial remain the known-good host settings
+- Imported the interaction-layer protocol into local repo memory as well:
+  - `开口` / `收口` are explicit session-control commands in this repo
+  - the markdown memory system itself is part of the collaboration contract
+  - stable protocol and user interaction expectations should be persisted under
+    `mimiclaw`, not left only in chat
+- Captured an explicit cross-workspace requirement:
+  when the user switches from the `esp32` workspace into `mimiclaw`, work here
+  should resume seamlessly from imported local memory rather than requiring the
+  same board / workflow context to be re-explained.
+- `main/mimi_secrets.h` is missing, so the next session should not rebuild from
+  scratch first; it should configure Wi-Fi / channel / API credentials on the
+  already working flashed image or create `mimi_secrets.h` intentionally if
+  build-time defaults are preferred.
+- Runtime board configuration is now live in NVS:
+  - Wi-Fi: `mynet`
+  - Feishu credentials saved and load correctly on boot
+  - LLM provider: `openai`
+  - model: `qwen3.5-plus`
+  - base URL: `https://coding.dashscope.aliyuncs.com/v1`
+  - API key saved
+- The repo code now supports an NVS-backed/customizable LLM base URL:
+  - new CLI command: `set_base_url <url>`
+  - `config_show` now prints `Base URL`
+  - OpenAI-compatible URLs that end at `/v1` are normalized to
+    `/v1/chat/completions`
+  - the proxy path now parses host / path from the configured URL instead of
+    assuming `api.openai.com`
+- Build and flash status after the base-URL change:
+  - the modified firmware rebuilt successfully with
+    `/Users/lize/.espressif/python_env/idf5.5_py3.14_env`
+  - the updated image was reflashed successfully to `/dev/cu.usbserial-10`
+- Validation status after the reflash:
+  - boot logs show `LLM proxy initialized (provider: openai, model: qwen3.5-plus)`
+  - Feishu WebSocket reaches `Feishu WS connected`
+  - a host-side WebSocket gateway test sent `Reply with exactly: pong`
+  - the board issued a real LLM call against the configured OpenAI-compatible
+    endpoint and returned `pong`
+- Remaining gap:
+  the OpenAI-compatible path is validated end-to-end through the board's local
+  WebSocket gateway, and the user has now confirmed that a real Feishu in-chat
+  roundtrip also works from the actual Feishu client.
+- This means the first true production-like channel path on the local board is
+  no longer hypothetical:
+  `Feishu inbound -> agent loop -> DashScope OpenAI-compatible model -> Feishu outbound`
+  has been verified in practice.

--- a/resume-queue.md
+++ b/resume-queue.md
@@ -1,0 +1,106 @@
+# Resume Queue
+
+## Primary Resume Target
+
+Use the now-validated `ATK-DNESP32S3` + `Feishu` + OpenAI-compatible LLM
+baseline to decide the next engineering step after first real channel success:
+either clean up doc drift, promote runtime config to build-time defaults, or
+continue with additional channel / tool validation.
+
+## Secondary Pending Items
+
+- Decide whether to update `docs/ARCHITECTURE.md` and Feishu docs to match the
+  current runtime-config + WebSocket-only implementation
+- Only create `main/mimi_secrets.h` later if persistent build-time defaults are
+  preferred over the already working NVS configuration
+- Decide whether to validate Telegram next or stay focused on Feishu-first
+  hardening
+
+## Latest Verified State
+
+- The repo is an `ESP-IDF` firmware project for `ESP32-S3`
+- It expects `16MB` flash, `8MB` PSRAM, Wi-Fi, and a serial / USB console
+- It does not currently appear to depend on LCD, camera, TF, or audio hardware
+- The local `ATK-DNESP32S3` board matches the required MCU / flash / PSRAM on paper
+- Prior hardware bring-up outside this repo already validated:
+  - red status LED control on `GPIO1` (active-low)
+  - LCD output on the `ST7789V` path after the `XL9555` board-control fix
+  - TF / microSD mount + read/write on the shared LCD/TF SPI bus
+- The repo constraint from `main/idf_component.yml`
+  (`ESP-IDF >=5.5.0,<5.6.0`) is now satisfied by the local working environment
+- Version choice has been decided: use `ESP-IDF v5.5.2` as the next build target
+- The working local environment for this repo is:
+  - `ESP-IDF` checkout: `/Users/lize/.espressif/esp-idf-v5.5.2`
+  - Python env: `/Users/lize/.espressif/python_env/idf5.5_py3.14_env`
+- `IDF_DIR=/Users/lize/.espressif/esp-idf-v5.5.2 /bin/bash scripts/build_macos.sh`
+  now completes successfully on this machine
+- The compiled image was flashed successfully to `/dev/cu.usbserial-10` at
+  `460800`
+- This board's known-good host interaction path remains:
+  - flash on `/dev/cu.usbserial-10` at `460800`
+  - serial / CLI at `115200`
+- Serial verification at `115200` confirmed:
+  - bootloader and app both report `ESP-IDF v5.5.2`
+  - PSRAM detection succeeds (`8MB`)
+  - SPIFFS mounts successfully
+  - the serial CLI prompt is reachable as `mimi>`
+  - `help` returns the expected command list
+- Board-level implication for `mimiclaw`:
+  prior LED / LCD / TF bring-up success means current work should stay focused
+  on runtime configuration and network/channel validation unless fresh hardware
+  symptoms appear
+- `main/mimi_secrets.h` is currently absent, so the flashed firmware boots into
+  an NVS-configured state rather than relying on build-time secrets
+- Runtime credentials are now configured in NVS on the board:
+  - Wi-Fi SSID `mynet`
+  - Feishu App ID / App Secret
+  - provider `openai`
+  - model `qwen3.5-plus`
+  - base URL `https://coding.dashscope.aliyuncs.com/v1`
+  - API key set
+- The firmware now includes a new CLI command `set_base_url <url>` and a new
+  NVS-backed `Base URL` field in `config_show`
+- The updated firmware was rebuilt under the validated local `ESP-IDF v5.5.2`
+  environment and reflashed successfully to `/dev/cu.usbserial-10`
+- Serial verification after the reflash confirmed:
+  - `llm_proxy` initializes as `provider: openai, model: qwen3.5-plus`
+  - Feishu credentials load from NVS
+  - Feishu WebSocket mode starts and reaches `Feishu WS connected`
+  - Wi-Fi still reconnects successfully and gets `192.168.31.165`
+- Host-driven WebSocket validation against the board gateway confirmed the
+  OpenAI-compatible LLM path is live:
+  - a local test message `Reply with exactly: pong` was delivered into the
+    agent loop
+  - the board called the configured LLM endpoint with provider `openai`
+  - the final assistant response returned as `pong`
+- The user has now confirmed the real Feishu in-chat path also works end-to-end
+  on hardware, so the first true channel validation is complete
+- This repo has adopted the markdown-first layered memory system in this file set
+
+## Next Concrete Step
+
+Keep the current flashed firmware and move from first-channel bring-up into
+cleanup / next-target planning:
+
+1. Update drifted docs so they match reality:
+   - runtime config exists
+   - CLI command is `set_wifi`, not `wifi_set`
+   - Feishu channel runs in WebSocket mode, not the older webhook-only story
+2. Decide whether the current working NVS config should remain runtime-only or
+   be represented by a local `main/mimi_secrets.h` for reproducibility
+3. Choose the next validation target:
+   - Telegram channel
+   - Feishu hardening / permissions / UX
+   - tool coverage beyond the basic reply path
+
+## Resume Reading Path
+
+For the next session, read:
+
+1. `AGENTS.md`
+2. `resume-queue.md`
+3. `MEMORY.md`
+4. `README.md`
+5. `docs/ARCHITECTURE.md`
+6. `main/idf_component.yml`
+7. the latest file in `memory/`


### PR DESCRIPTION
## Summary
- add NVS-backed configurable LLM base URL support for OpenAI-compatible providers
- expose the new runtime setting through the serial CLI and config display
- update local handoff/docs to reflect the validated Feishu + OpenAI-compatible setup

## Validation
- rebuilt the firmware with ESP-IDF v5.5.2
- reflashed the board on /dev/cu.usbserial-10
- configured Feishu, OpenAI-compatible base URL, model, and API key via CLI
- verified a live roundtrip on hardware, including a WebSocket-injected test prompt returning \pong\ and a real Feishu chat confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `set_base_url` CLI command to configure LLM base URL at runtime for OpenAI-compatible providers
  * New configuration option for LLM base URL persisted across sessions

* **Documentation**
  * Added comprehensive documentation for session memory system and cross-session continuity
  * Added decision log outlining project architecture and strategic decisions

* **Updates**
  * Renamed WiFi configuration command from `wifi_set` to `set_wifi`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->