### PR TITLE
Fix: Add Reach Max Tool Iter Debug Info

### DIFF
--- a/main/agent/agent_loop.c
+++ b/main/agent/agent_loop.c
@@ -270,6 +270,9 @@ static void agent_loop_task(void *arg)
             iteration++;
         }
 
+        if (iteration >= MIMI_AGENT_MAX_TOOL_ITER) {
+            ESP_LOGE(TAG, "Reached maximum tool iterations, stop processing");
+        }
         cJSON_Delete(messages);
 
         /* 5. Send response */


### PR DESCRIPTION
Fix: Add Reach Max Tool Iter Debug Info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when the agent reaches the maximum tool-iteration limit: users will now see a clear notice indicating processing stopped due to hitting the iteration cap, making failures easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->