### PR TITLE
feat: include spiffs.bin in release and switch console to USB-JTAG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,22 +28,24 @@ jobs:
           . $IDF_PATH/export.sh
           VERSION="${GITHUB_REF_NAME}"
 
-          # Generate merged firmware for single-command flashing
+          # Generate merged firmware for single-command flashing (includes SPIFFS)
           esptool.py --chip esp32s3 merge_bin \
             --flash_mode qio \
             --flash_size 16MB \
             --flash_freq 80m \
             -o "mimiclaw-full-${VERSION}.bin" \
-            0x0     build/bootloader/bootloader.bin \
-            0x8000  build/partition_table/partition-table.bin \
-            0xf000  build/ota_data_initial.bin \
-            0x20000 build/mimiclaw.bin
+            0x0      build/bootloader/bootloader.bin \
+            0x8000   build/partition_table/partition-table.bin \
+            0xf000   build/ota_data_initial.bin \
+            0x20000  build/mimiclaw.bin \
+            0x420000 build/spiffs.bin
 
           # Copy individual binaries with version suffix
           cp build/mimiclaw.bin              "mimiclaw-${VERSION}.bin"
           cp build/bootloader/bootloader.bin "bootloader-${VERSION}.bin"
           cp build/partition_table/partition-table.bin "partition-table-${VERSION}.bin"
           cp build/ota_data_initial.bin      "ota_data_initial-${VERSION}.bin"
+          cp build/spiffs.bin                "spiffs-${VERSION}.bin"
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -64,10 +66,11 @@ jobs:
 
             ```bash
             esptool.py --chip esp32s3 -b 460800 write_flash \
-              0x0     bootloader-${{ github.ref_name }}.bin \
-              0x8000  partition-table-${{ github.ref_name }}.bin \
-              0xf000  ota_data_initial-${{ github.ref_name }}.bin \
-              0x20000 mimiclaw-${{ github.ref_name }}.bin
+              0x0      bootloader-${{ github.ref_name }}.bin \
+              0x8000   partition-table-${{ github.ref_name }}.bin \
+              0xf000   ota_data_initial-${{ github.ref_name }}.bin \
+              0x20000  mimiclaw-${{ github.ref_name }}.bin \
+              0x420000 spiffs-${{ github.ref_name }}.bin
             ```
 
             ### 3. OTA update (for devices already running MimiClaw)
@@ -90,3 +93,4 @@ jobs:
             bootloader-${{ github.ref_name }}.bin
             partition-table-${{ github.ref_name }}.bin
             ota_data_initial-${{ github.ref_name }}.bin
+            spiffs-${{ github.ref_name }}.bin

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,7 +35,7 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# Console: UART primary (non-blocking), USB Serial/JTAG secondary
-# Prevents device hang when no USB host is connected (issue #60)
-CONFIG_ESP_CONSOLE_UART_DEFAULT=y
-CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+# Console: USB Serial/JTAG primary (supports both input and output via USB)
+# ESP-IDF v5.5+ has TX timeout protection (50ms) so device won't hang
+# when no USB host is connected.
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y


### PR DESCRIPTION
Add spiffs.bin to CI release artifacts and merged firmware image. Switch primary console from UART to USB-Serial-JTAG so web serial monitor can interact with the device directly over USB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SPIFFS now included in firmware releases as part of the merged firmware image and distributed with version-tagged binaries.

* **Chores**
  * Updated console configuration to use USB Serial/JTAG instead of UART.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->