### PR TITLE
feat: add custom LLM base URL configuration

### DIFF
--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -171,6 +171,24 @@ static int cmd_set_model_provider(int argc, char **argv)
     return 0;
 }
 
+/* --- set_base_url command --- */
+static struct {
+    struct arg_str *url;
+    struct arg_end *end;
+} base_url_args;
+
+static int cmd_set_base_url(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&base_url_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, base_url_args.end, argv[0]);
+        return 1;
+    }
+    llm_set_base_url(base_url_args.url->sval[0]);
+    printf("Base URL set.\n");
+    return 0;
+}
+
 /* --- memory_read command --- */
 static int cmd_memory_read(int argc, char **argv)
 {
@@ -559,10 +577,12 @@ static int cmd_config_show(int argc, char **argv)
     printf("=== Current Configuration ===\n");
     print_config("WiFi SSID",  MIMI_NVS_WIFI,   MIMI_NVS_KEY_SSID,     MIMI_SECRET_WIFI_SSID,  false);
     print_config("WiFi Pass",  MIMI_NVS_WIFI,   MIMI_NVS_KEY_PASS,     MIMI_SECRET_WIFI_PASS,  true);
+    printf("  %-14s: %s\n", "IP Address", wifi_manager_get_ip());
     print_config("TG Token",   MIMI_NVS_TG,     MIMI_NVS_KEY_TG_TOKEN, MIMI_SECRET_TG_TOKEN,   true);
     print_config("API Key",    MIMI_NVS_LLM,    MIMI_NVS_KEY_API_KEY,  MIMI_SECRET_API_KEY,    true);
     print_config("Model",      MIMI_NVS_LLM,    MIMI_NVS_KEY_MODEL,    MIMI_SECRET_MODEL,      false);
     print_config("Provider",   MIMI_NVS_LLM,    MIMI_NVS_KEY_PROVIDER, MIMI_SECRET_MODEL_PROVIDER, false);
+    print_config("Base URL",   MIMI_NVS_LLM,    MIMI_NVS_KEY_BASE_URL, MIMI_SECRET_BASE_URL,   false);
     print_config("Proxy Host", MIMI_NVS_PROXY,  MIMI_NVS_KEY_PROXY_HOST, MIMI_SECRET_PROXY_HOST, false);
     print_config_u16("Proxy Port", MIMI_NVS_PROXY, MIMI_NVS_KEY_PROXY_PORT, MIMI_SECRET_PROXY_PORT);
     print_config("Search Key", MIMI_NVS_SEARCH, MIMI_NVS_KEY_API_KEY,  MIMI_SECRET_SEARCH_KEY, true);
@@ -896,6 +916,17 @@ esp_err_t serial_cli_init(void)
         .argtable = &provider_args,
     };
     esp_console_cmd_register(&provider_cmd);
+
+    /* set_base_url */
+    base_url_args.url = arg_str1(NULL, NULL, "<url>", "Base URL (e.g. https://my-server.com/), empty to clear");
+    base_url_args.end = arg_end(1);
+    esp_console_cmd_t base_url_cmd = {
+        .command = "set_base_url",
+        .help = "Set custom LLM base URL (appends provider path automatically)",
+        .func = &cmd_set_base_url,
+        .argtable = &base_url_args,
+    };
+    esp_console_cmd_register(&base_url_cmd);
 
     /* skill_list */
     esp_console_cmd_t skill_list_cmd = {

--- a/main/llm/llm_proxy.c
+++ b/main/llm/llm_proxy.c
@@ -15,12 +15,14 @@ static const char *TAG = "llm";
 
 #define LLM_API_KEY_MAX_LEN 320
 #define LLM_MODEL_MAX_LEN   64
+#define LLM_BASE_URL_MAX_LEN 256
 #define LLM_DUMP_MAX_BYTES   (16 * 1024)
 #define LLM_DUMP_CHUNK_BYTES 320
 
 static char s_api_key[LLM_API_KEY_MAX_LEN] = {0};
 static char s_model[LLM_MODEL_MAX_LEN] = MIMI_LLM_DEFAULT_MODEL;
 static char s_provider[16] = MIMI_LLM_PROVIDER_DEFAULT;
+static char s_base_url[LLM_BASE_URL_MAX_LEN] = {0};
 
 static void llm_log_payload(const char *label, const char *payload)
 {
@@ -187,8 +189,15 @@ static bool provider_is_openai(void)
     return strcmp(s_provider, "openai") == 0;
 }
 
+static const char *llm_api_path(void);  /* forward declaration */
+
 static const char *llm_api_url(void)
 {
+    if (s_base_url[0] != '\0') {
+        static char full_url[512];
+        snprintf(full_url, sizeof(full_url), "%s%s", s_base_url, llm_api_path());
+        return full_url;
+    }
     return provider_is_openai() ? MIMI_OPENAI_API_URL : MIMI_LLM_API_URL;
 }
 
@@ -216,6 +225,9 @@ esp_err_t llm_proxy_init(void)
     if (MIMI_SECRET_MODEL_PROVIDER[0] != '\0') {
         safe_copy(s_provider, sizeof(s_provider), MIMI_SECRET_MODEL_PROVIDER);
     }
+    if (MIMI_SECRET_BASE_URL[0] != '\0') {
+        safe_copy(s_base_url, sizeof(s_base_url), MIMI_SECRET_BASE_URL);
+    }
 
     /* NVS overrides take highest priority (set via CLI) */
     nvs_handle_t nvs;
@@ -235,11 +247,16 @@ esp_err_t llm_proxy_init(void)
         if (nvs_get_str(nvs, MIMI_NVS_KEY_PROVIDER, provider_tmp, &len) == ESP_OK && provider_tmp[0]) {
             safe_copy(s_provider, sizeof(s_provider), provider_tmp);
         }
+        char base_url_tmp[LLM_BASE_URL_MAX_LEN] = {0};
+        len = sizeof(base_url_tmp);
+        if (nvs_get_str(nvs, MIMI_NVS_KEY_BASE_URL, base_url_tmp, &len) == ESP_OK && base_url_tmp[0]) {
+            safe_copy(s_base_url, sizeof(s_base_url), base_url_tmp);
+        }
         nvs_close(nvs);
     }
 
     if (s_api_key[0]) {
-        ESP_LOGI(TAG, "LLM proxy initialized (provider: %s, model: %s)", s_provider, s_model);
+        ESP_LOGI(TAG, "LLM proxy initialized (provider: %s, model: %s, base_url: %s)", s_provider, s_model, s_base_url[0] ? s_base_url : "(default)");
     } else {
         ESP_LOGW(TAG, "No API key. Use CLI: set_api_key <KEY>");
     }
@@ -807,5 +824,22 @@ esp_err_t llm_set_provider(const char *provider)
 
     safe_copy(s_provider, sizeof(s_provider), provider);
     ESP_LOGI(TAG, "Provider set to: %s", s_provider);
+    return ESP_OK;
+}
+
+esp_err_t llm_set_base_url(const char *base_url)
+{
+    nvs_handle_t nvs;
+    ESP_ERROR_CHECK(nvs_open(MIMI_NVS_LLM, NVS_READWRITE, &nvs));
+    ESP_ERROR_CHECK(nvs_set_str(nvs, MIMI_NVS_KEY_BASE_URL, base_url));
+    ESP_ERROR_CHECK(nvs_commit(nvs));
+    nvs_close(nvs);
+
+    safe_copy(s_base_url, sizeof(s_base_url), base_url);
+    if (s_base_url[0]) {
+        ESP_LOGI(TAG, "Base URL set to: %s", s_base_url);
+    } else {
+        ESP_LOGI(TAG, "Base URL cleared (using provider defaults)");
+    }
     return ESP_OK;
 }

--- a/main/llm/llm_proxy.h
+++ b/main/llm/llm_proxy.h
@@ -27,6 +27,13 @@ esp_err_t llm_set_provider(const char *provider);
  */
 esp_err_t llm_set_model(const char *model);
 
+/**
+ * Save the LLM base URL to NVS. (e.g. "https://my-server.com/")
+ * When set, this overrides the default provider URLs.
+ * The provider-specific path is appended automatically.
+ */
+esp_err_t llm_set_base_url(const char *base_url);
+
 /* ── Tool Use Support ──────────────────────────────────────────── */
 
 typedef struct {

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -46,6 +46,9 @@
 #ifndef MIMI_SECRET_TAVILY_KEY
 #define MIMI_SECRET_TAVILY_KEY      ""
 #endif
+#ifndef MIMI_SECRET_BASE_URL
+#define MIMI_SECRET_BASE_URL        ""
+#endif
 
 /* WiFi */
 #define MIMI_WIFI_MAX_RETRY          10
@@ -153,6 +156,7 @@
 #define MIMI_NVS_KEY_PROXY_HOST      "host"
 #define MIMI_NVS_KEY_PROXY_PORT      "port"
 #define MIMI_NVS_KEY_PROXY_TYPE      "proxy_type"
+#define MIMI_NVS_KEY_BASE_URL        "base_url"
 
 /* WiFi Onboarding (Captive Portal) */
 #define MIMI_ONBOARD_AP_PREFIX    "MimiClaw-"

--- a/main/onboard/onboard_html.h
+++ b/main/onboard/onboard_html.h
@@ -60,6 +60,8 @@ static const char ONBOARD_HTML[] =
 "<option value='anthropic'>Anthropic</option>"
 "<option value='openai'>OpenAI</option>"
 "</select>"
+"<label>Base URL (optional)</label>"
+"<input id='base_url' placeholder='https://your-custom-api.com/v1'>"
 "</div></div>"
 
 /* Telegram section */
@@ -134,7 +136,7 @@ static const char ONBOARD_HTML[] =
 "}).catch(()=>{btn.textContent='Scan WiFi Networks';btn.disabled=false})}"
 
 "function save(){"
-"var fields=['ssid','password','api_key','model','provider','tg_token',"
+"var fields=['ssid','password','api_key','model','provider','base_url','tg_token',"
 "'feishu_app_id','feishu_app_secret','proxy_host','proxy_port','proxy_type','search_key','tavily_key'];"
 "var data={};"
 "fields.forEach(f=>{data[f]=document.getElementById(f).value.trim()});"

--- a/main/onboard/wifi_onboard.c
+++ b/main/onboard/wifi_onboard.c
@@ -220,6 +220,7 @@ static esp_err_t http_get_config(httpd_req_t *req)
     json_add_effective_config(root, "api_key", MIMI_NVS_LLM, MIMI_NVS_KEY_API_KEY, MIMI_SECRET_API_KEY);
     json_add_effective_config(root, "model", MIMI_NVS_LLM, MIMI_NVS_KEY_MODEL, MIMI_SECRET_MODEL);
     json_add_effective_config(root, "provider", MIMI_NVS_LLM, MIMI_NVS_KEY_PROVIDER, MIMI_SECRET_MODEL_PROVIDER);
+    json_add_effective_config(root, "base_url", MIMI_NVS_LLM, MIMI_NVS_KEY_BASE_URL, MIMI_SECRET_BASE_URL);
     json_add_effective_config(root, "tg_token", MIMI_NVS_TG, MIMI_NVS_KEY_TG_TOKEN, MIMI_SECRET_TG_TOKEN);
     json_add_effective_config(root, "feishu_app_id", MIMI_NVS_FEISHU, MIMI_NVS_KEY_FEISHU_APP_ID, MIMI_SECRET_FEISHU_APP_ID);
     json_add_effective_config(root, "feishu_app_secret", MIMI_NVS_FEISHU, MIMI_NVS_KEY_FEISHU_APP_SECRET, MIMI_SECRET_FEISHU_APP_SECRET);
@@ -343,6 +344,7 @@ static esp_err_t http_post_save(httpd_req_t *req)
     nvs_sync_field(root, "api_key",  MIMI_NVS_LLM,    MIMI_NVS_KEY_API_KEY);
     nvs_sync_field(root, "model",    MIMI_NVS_LLM,    MIMI_NVS_KEY_MODEL);
     nvs_sync_field(root, "provider", MIMI_NVS_LLM,    MIMI_NVS_KEY_PROVIDER);
+    nvs_sync_field(root, "base_url", MIMI_NVS_LLM,    MIMI_NVS_KEY_BASE_URL);
 
     /* Telegram */
     nvs_sync_field(root, "tg_token", MIMI_NVS_TG,     MIMI_NVS_KEY_TG_TOKEN);


### PR DESCRIPTION
- Add set_base_url CLI command to configure custom LLM endpoint
- Store base URL in NVS for persistence
- Update llm_proxy to use custom base URL when set (appends provider path)
- Add base_url field to onboard HTML configuration page
- Display IP address and base URL in config show output
- Add MIMI_SECRET_BASE_URL and MIMI_NVS_KEY_BASE_URL config defines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM base URL support via CLI command and web-based onboarding UI
  * Custom base URL overrides default provider endpoints with automatic path appending
  * Base URL configuration is persisted and displayed in system status output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->