### PR TITLE
fix: revert console to UART primary so device boots on USB-only power

### DIFF
--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -35,7 +35,12 @@ CONFIG_HTTPD_WS_SUPPORT=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# Console: USB Serial/JTAG primary (supports both input and output via USB)
-# ESP-IDF v5.5+ has TX timeout protection (50ms) so device won't hang
-# when no USB host is connected.
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+# Console: UART primary (non-blocking), USB Serial/JTAG secondary.
+# Using USB-JTAG as the primary console caused boot to stall when the
+# device was powered from a USB charger/power bank with no host attached
+# (early ESP_LOGI calls in app_main block on the USB CDC TX queue).
+# UART as primary is non-blocking when nothing is connected, and the
+# secondary USB-JTAG still works for flash + debug + log output via the
+# USB port (matches the workflow documented in README.md).
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y


### PR DESCRIPTION
## Summary

Commit 2b68d56 (`feat: include spiffs.bin in release and switch console to USB-JTAG`) switched the primary console to `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y`. In practice this regresses standalone (host-less) operation on ESP32-S3:

- When the board is powered from a USB charger or power bank with **no host PC attached**, the early `ESP_LOGI` calls in `app_main` block on the USB CDC TX queue and boot never progresses past the banner.
- The 50 ms TX timeout that motivated the switch is not enough to cover all standalone-power scenarios; users report the device "only works while plugged into a computer".
- `README.md` line 215 still documents the previous configuration (`CONFIG_ESP_CONSOLE_UART_DEFAULT=y`), so the sdkconfig and the docs are currently out of sync.

This PR restores the configuration that was in place before 2b68d56 (matching commit 10c9a5e and the workflow described in the README):

```diff
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
```

UART as primary is non-blocking when nothing is connected. The secondary USB-Serial/JTAG keeps flash, debug, and log output working through the USB port, so the `idf.py -p <usb-jtag-port> flash monitor` workflow is unaffected. The unrelated `spiffs.bin`-in-release change from 2b68d56 is left intact.

## Test plan

- [ ] Build with the patched sdkconfig: `idf.py fullclean && idf.py build`
- [ ] Flash via the USB-JTAG port: `idf.py -p <PORT> flash monitor` — logs still appear via USB
- [ ] Disconnect from the host PC and power the board from a USB charger or power bank
- [ ] Confirm the device joins WiFi and the Telegram bot starts responding (verify via router DHCP table or by messaging the bot)
- [ ] REPL still works on the UART port as documented in `README.md` "USB (JTAG) vs UART" section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console and serial configuration to use UART as the primary console with USB Serial/JTAG maintained as secondary for flash, debug, and log operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->