### PR TITLE
feat: optional one-time Telegram notification on first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ Edit `main/mimi_secrets.h`:
 #define MIMI_SECRET_TAVILY_KEY      ""              // optional: Tavily API key (preferred)
 #define MIMI_SECRET_PROXY_HOST      ""              // optional: e.g. "10.0.0.1"
 #define MIMI_SECRET_PROXY_PORT      ""              // optional: e.g. "7897"
+#define MIMI_SECRET_TG_ADMIN_CHAT_ID ""             // optional: enables first-boot Telegram notice
 ```
+
+> **First-boot Telegram notification (optional).** Set `MIMI_SECRET_TG_ADMIN_CHAT_ID` to your chat ID (get it from [@userinfobot](https://t.me/userinfobot) on Telegram) and the device will send a one-time "MimiClaw booted" message — with IP and timestamp — the first time it comes online after flashing. The flag is persisted in NVS so subsequent boots are silent. Set `MIMI_TG_SEND_FIRST_BOOT` to `0` in `main/mimi_config.h` to disable the feature, or run `reset_first_boot` from the serial CLI to re-arm it without erasing NVS.
 
 Then build and flash:
 
@@ -190,6 +193,7 @@ mimi> session_list             # list all chat sessions
 mimi> session_clear 12345      # wipe a conversation
 mimi> heartbeat_trigger           # manually trigger a heartbeat check
 mimi> cron_start                  # start cron scheduler now
+mimi> reset_first_boot            # re-arm the first-boot Telegram notice
 mimi> restart                     # reboot
 ```
 

--- a/main/channels/telegram/telegram_bot.c
+++ b/main/channels/telegram/telegram_bot.c
@@ -2,6 +2,9 @@
 #include "mimi_config.h"
 #include "bus/message_bus.h"
 #include "proxy/http_proxy.h"
+#include "wifi/wifi_manager.h"
+
+#include <time.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -560,4 +563,79 @@ esp_err_t telegram_set_token(const char *token)
     strncpy(s_bot_token, token, sizeof(s_bot_token) - 1);
     ESP_LOGI(TAG, "Telegram bot token saved");
     return ESP_OK;
+}
+
+esp_err_t telegram_send_first_boot_notice(void)
+{
+#if !MIMI_TG_SEND_FIRST_BOOT
+    return ESP_OK;
+#else
+    const char *chat_id = MIMI_SECRET_TG_ADMIN_CHAT_ID;
+    if (!chat_id || chat_id[0] == '\0') {
+        ESP_LOGW(TAG, "First-boot notice enabled but MIMI_SECRET_TG_ADMIN_CHAT_ID is empty");
+        return ESP_OK;
+    }
+    if (s_bot_token[0] == '\0') {
+        ESP_LOGW(TAG, "First-boot notice: bot token not configured");
+        return ESP_OK;
+    }
+
+    nvs_handle_t nvs;
+    if (nvs_open(MIMI_NVS_TG, NVS_READWRITE, &nvs) != ESP_OK) {
+        ESP_LOGW(TAG, "First-boot notice: NVS open failed");
+        return ESP_OK;
+    }
+
+    uint8_t done = 0;
+    esp_err_t get_err = nvs_get_u8(nvs, MIMI_NVS_KEY_FIRST_BOOT_DONE, &done);
+    if (get_err == ESP_OK && done == 1) {
+        nvs_close(nvs);
+        return ESP_OK;
+    }
+
+    char msg[256];
+    const char *ip = wifi_manager_get_ip();
+    time_t now = time(NULL);
+    struct tm tm_info;
+    char ts[32] = "(time not set)";
+    if (now > 1700000000) {
+        localtime_r(&now, &tm_info);
+        strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm_info);
+    }
+    snprintf(msg, sizeof(msg),
+             "MimiClaw booted.\n"
+             "IP: %s\n"
+             "Time: %s",
+             (ip && ip[0]) ? ip : "(unknown)", ts);
+
+    esp_err_t send_err = telegram_send_message(chat_id, msg);
+    if (send_err == ESP_OK) {
+        if (nvs_set_u8(nvs, MIMI_NVS_KEY_FIRST_BOOT_DONE, 1) == ESP_OK) {
+            nvs_commit(nvs);
+        }
+        ESP_LOGI(TAG, "First-boot notice sent to %s", chat_id);
+    } else {
+        ESP_LOGW(TAG, "First-boot notice send failed: %s (will retry next boot)",
+                 esp_err_to_name(send_err));
+    }
+    nvs_close(nvs);
+    return ESP_OK;
+#endif
+}
+
+esp_err_t telegram_reset_first_boot_flag(void)
+{
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(MIMI_NVS_TG, NVS_READWRITE, &nvs);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = nvs_erase_key(nvs, MIMI_NVS_KEY_FIRST_BOOT_DONE);
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) {
+        nvs_commit(nvs);
+        err = ESP_OK;
+    }
+    nvs_close(nvs);
+    ESP_LOGI(TAG, "First-boot flag cleared; next boot will re-send notice");
+    return err;
 }

--- a/main/channels/telegram/telegram_bot.h
+++ b/main/channels/telegram/telegram_bot.h
@@ -25,3 +25,20 @@ esp_err_t telegram_send_message(const char *chat_id, const char *text);
  */
 esp_err_t telegram_set_token(const char *token);
 
+/**
+ * Send a one-time "device booted" notification to the admin chat.
+ *
+ * No-op when MIMI_TG_SEND_FIRST_BOOT is 0, MIMI_SECRET_TG_ADMIN_CHAT_ID
+ * is empty, or the NVS flag MIMI_NVS_KEY_FIRST_BOOT_DONE is already set.
+ * On a successful send the flag is written so subsequent boots are silent.
+ * If sending fails the flag is left unset so the next boot can retry.
+ * Always returns ESP_OK so callers can ignore the result on boot path.
+ */
+esp_err_t telegram_send_first_boot_notice(void);
+
+/**
+ * Clear the first-boot-done NVS flag so the next boot re-sends the
+ * notification (useful for testing without erasing the whole NVS).
+ */
+esp_err_t telegram_reset_first_boot_flag(void);
+

--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -76,6 +76,20 @@ static int cmd_set_tg_token(int argc, char **argv)
     return 0;
 }
 
+/* --- reset_first_boot command --- */
+static int cmd_reset_first_boot(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    esp_err_t err = telegram_reset_first_boot_flag();
+    if (err == ESP_OK) {
+        printf("First-boot flag cleared. Next boot will re-send the Telegram notice.\n");
+        return 0;
+    }
+    printf("Failed to clear first-boot flag: %s\n", esp_err_to_name(err));
+    return 1;
+}
+
 /* --- set_feishu_creds command --- */
 static struct {
     struct arg_str *app_id;
@@ -839,6 +853,14 @@ esp_err_t serial_cli_init(void)
         .argtable = &tg_token_args,
     };
     esp_console_cmd_register(&tg_token_cmd);
+
+    /* reset_first_boot */
+    esp_console_cmd_t reset_first_boot_cmd = {
+        .command = "reset_first_boot",
+        .help = "Clear the first-boot Telegram-notice flag so the next boot re-sends it",
+        .func = &cmd_reset_first_boot,
+    };
+    esp_console_cmd_register(&reset_first_boot_cmd);
 
     /* set_feishu_creds */
     feishu_creds_args.app_id = arg_str1(NULL, NULL, "<app_id>", "Feishu App ID");

--- a/main/mimi.c
+++ b/main/mimi.c
@@ -178,6 +178,7 @@ void app_main(void)
         /* Start network-dependent services */
         ESP_ERROR_CHECK(agent_loop_start());
         ESP_ERROR_CHECK(telegram_bot_start());
+        telegram_send_first_boot_notice();  /* non-fatal: silent unless first boot */
         ESP_ERROR_CHECK(feishu_bot_start());
         cron_service_start();
         heartbeat_start();

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -16,6 +16,9 @@
 #ifndef MIMI_SECRET_TG_TOKEN
 #define MIMI_SECRET_TG_TOKEN        ""
 #endif
+#ifndef MIMI_SECRET_TG_ADMIN_CHAT_ID
+#define MIMI_SECRET_TG_ADMIN_CHAT_ID ""
+#endif
 #ifndef MIMI_SECRET_API_KEY
 #define MIMI_SECRET_API_KEY         ""
 #endif
@@ -60,6 +63,12 @@
 #define MIMI_TG_POLL_CORE            0
 #define MIMI_TG_CARD_SHOW_MS         3000
 #define MIMI_TG_CARD_BODY_SCALE      3
+
+/* First-boot Telegram notification.
+ * Set to 0 to disable the one-time "device booted" message. When enabled,
+ * the device sends a single message to MIMI_SECRET_TG_ADMIN_CHAT_ID on the
+ * first boot after flashing (idempotent — guarded by an NVS flag). */
+#define MIMI_TG_SEND_FIRST_BOOT      1
 
 /* Feishu Bot */
 #define MIMI_FEISHU_MAX_MSG_LEN          4096
@@ -144,6 +153,7 @@
 #define MIMI_NVS_KEY_SSID            "ssid"
 #define MIMI_NVS_KEY_PASS            "password"
 #define MIMI_NVS_KEY_TG_TOKEN        "bot_token"
+#define MIMI_NVS_KEY_FIRST_BOOT_DONE "fb_done"
 #define MIMI_NVS_KEY_FEISHU_APP_ID   "app_id"
 #define MIMI_NVS_KEY_FEISHU_APP_SECRET "app_secret"
 #define MIMI_NVS_KEY_API_KEY         "api_key"

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -17,6 +17,12 @@
 /* Telegram Bot */
 #define MIMI_SECRET_TG_TOKEN        ""
 
+/* Telegram admin chat ID (optional).
+ * If set together with MIMI_TG_SEND_FIRST_BOOT=1 in mimi_config.h, the
+ * device sends a one-time "booted" message to this chat on first boot.
+ * Get yours by messaging @userinfobot on Telegram. */
+#define MIMI_SECRET_TG_ADMIN_CHAT_ID ""
+
 /* Feishu Bot */
 #define MIMI_SECRET_FEISHU_APP_ID   ""
 #define MIMI_SECRET_FEISHU_APP_SECRET ""


### PR DESCRIPTION
## Summary

Adds a build-time toggle and an idempotent, NVS-guarded notifier that sends a single "MimiClaw booted" message to a configured Telegram admin chat the first time the device comes online after flashing.

Why this is useful:

- Confirm remotely that the device came back up after a power cycle, OTA, or being relocated to a USB charger / power bank, without having to monitor serial.
- A self-contained no-op when the feature is disabled or the admin chat is not configured — zero impact on existing users.

## How it works

- `MIMI_TG_SEND_FIRST_BOOT` in `main/mimi_config.h` is the master toggle (defaults to `1`).
- `MIMI_SECRET_TG_ADMIN_CHAT_ID` in `mimi_secrets.h` holds the destination chat ID (defaults to empty — feature inert).
- `MIMI_NVS_KEY_FIRST_BOOT_DONE` lives in the existing `MIMI_NVS_TG` namespace and is set to `1` after a successful send, making subsequent boots silent.
- If sending fails (no network, invalid token, etc.) the NVS flag is left unset, so the next boot retries.
- The call site in `app_main` is intentionally not wrapped in `ESP_ERROR_CHECK` and the function always returns `ESP_OK`, so no failure mode here can block boot.

## What's in the diff

- `main/mimi_config.h` — new `MIMI_TG_SEND_FIRST_BOOT` flag, new NVS key, new optional secret fallback.
- `main/mimi_secrets.h.example` — new `MIMI_SECRET_TG_ADMIN_CHAT_ID` slot with inline guidance pointing to `@userinfobot`.
- `main/channels/telegram/telegram_bot.{h,c}` — `telegram_send_first_boot_notice()` (the guarded sender) and `telegram_reset_first_boot_flag()` (test helper).
- `main/mimi.c` — single call after `telegram_bot_start()` in the boot sequence.
- `main/cli/serial_cli.c` — `reset_first_boot` CLI command to re-arm the notifier without erasing NVS.
- `README.md` — documents the new secret, the toggle, and the CLI command.

No existing call sites or behaviours change. The notifier uses the public `telegram_send_message()` API and the standard `MIMI_NVS_TG` namespace pattern already used for the polling offset.

## Test plan

- [ ] Build: `idf.py fullclean && idf.py build`
- [ ] Erase NVS and flash: `idf.py -p <PORT> erase-flash flash monitor`
- [ ] With `MIMI_SECRET_TG_ADMIN_CHAT_ID` set and `MIMI_TG_SEND_FIRST_BOOT=1`: confirm a single Telegram message arrives once WiFi is up
- [ ] `mimi> restart` — no additional message (idempotent)
- [ ] `mimi> reset_first_boot` then `mimi> restart` — message is sent again
- [ ] Set `MIMI_TG_SEND_FIRST_BOOT 0`, rebuild and erase-flash — no message ever sent
- [ ] Robustness: leave `MIMI_SECRET_TG_ADMIN_CHAT_ID` empty with the flag enabled — boot continues normally with a single warn log, no crash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional first-boot Telegram notification sends device boot details (IP address and timestamp) to admin chat on startup; tracked persistently with ability to disable or resend
  * New CLI command to re-arm first-boot notification without full system reset

* **Documentation**
  * Updated README documenting first-boot notification configuration options and behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->