### PR TITLE
feat: sync system clock via SNTP on boot

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,6 +3,7 @@ idf_component_register(
         "mimi.c"
         "bus/message_bus.c"
         "wifi/wifi_manager.c"
+        "time/time_sync.c"
         "channels/telegram/telegram_bot.c"
         "channels/feishu/feishu_bot.c"
         "llm/llm_proxy.c"

--- a/main/mimi.c
+++ b/main/mimi.c
@@ -26,6 +26,7 @@
 #include "heartbeat/heartbeat.h"
 #include "skills/skill_loader.h"
 #include "onboard/wifi_onboard.h"
+#include "time/time_sync.h"
 
 static const char *TAG = "mimi";
 
@@ -150,6 +151,9 @@ void app_main(void)
         if (wifi_manager_wait_connected(30000) == ESP_OK) {
             wifi_ok = true;
             ESP_LOGI(TAG, "WiFi connected: %s", wifi_manager_get_ip());
+            /* Kick SNTP as soon as we have an IP so the RTC is set
+             * before time-sensitive code (session logs, cron, etc.). */
+            time_sync_start();
         } else {
             ESP_LOGW(TAG, "WiFi connection timeout");
         }

--- a/main/time/time_sync.c
+++ b/main/time/time_sync.c
@@ -1,0 +1,85 @@
+#include "time_sync.h"
+#include "mimi_config.h"
+
+#include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
+#include "esp_log.h"
+#include "esp_netif_sntp.h"
+#include "esp_sntp.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+static const char *TAG = "time_sync";
+
+#define TIME_SYNC_DONE_BIT  BIT0
+
+static EventGroupHandle_t s_evt = NULL;
+static bool s_started = false;
+
+static void on_time_set(struct timeval *tv)
+{
+    time_t now = tv ? tv->tv_sec : time(NULL);
+    struct tm local;
+    localtime_r(&now, &local);
+    char buf[40];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", &local);
+    ESP_LOGI(TAG, "System time synchronized: %s", buf);
+    if (s_evt) {
+        xEventGroupSetBits(s_evt, TIME_SYNC_DONE_BIT);
+    }
+}
+
+esp_err_t time_sync_start(void)
+{
+    if (s_started) {
+        return ESP_OK;
+    }
+
+    if (!s_evt) {
+        s_evt = xEventGroupCreate();
+        if (!s_evt) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    setenv("TZ", MIMI_TIMEZONE, 1);
+    tzset();
+
+    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+    config.start = true;
+    config.sync_cb = on_time_set;
+    config.smooth_sync = false;
+
+    esp_err_t err = esp_netif_sntp_init(&config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "SNTP init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    ESP_LOGI(TAG, "SNTP started (server=pool.ntp.org, tz=%s)", MIMI_TIMEZONE);
+    s_started = true;
+    return ESP_OK;
+}
+
+bool time_sync_wait(uint32_t timeout_ms)
+{
+    if (time_sync_is_set()) {
+        return true;
+    }
+    if (!s_evt) {
+        return false;
+    }
+    TickType_t ticks = (timeout_ms == portMAX_DELAY)
+        ? portMAX_DELAY
+        : pdMS_TO_TICKS(timeout_ms);
+    EventBits_t bits = xEventGroupWaitBits(s_evt, TIME_SYNC_DONE_BIT,
+                                           pdFALSE, pdTRUE, ticks);
+    return (bits & TIME_SYNC_DONE_BIT) != 0;
+}
+
+bool time_sync_is_set(void)
+{
+    time_t now = time(NULL);
+    return now > 1700000000;  /* > Nov 2023, same threshold used elsewhere */
+}

--- a/main/time/time_sync.h
+++ b/main/time/time_sync.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+
+/**
+ * Start SNTP synchronization in the background.
+ *
+ * Configures the system timezone from MIMI_TIMEZONE and asks lwIP/SNTP
+ * to keep the RTC in sync with pool.ntp.org. Returns immediately; the
+ * first sync arrives a few seconds later via a background callback.
+ * Safe to call multiple times — only the first call has effect.
+ * Should be called after WiFi has an IP.
+ */
+esp_err_t time_sync_start(void);
+
+/**
+ * Block until the system clock has been set at least once, or timeout.
+ * @param timeout_ms  Max wait (0 returns immediately, portMAX_DELAY = forever)
+ * @return true if time is set, false on timeout
+ */
+bool time_sync_wait(uint32_t timeout_ms);
+
+/**
+ * Whether the system clock has been set at least once since boot.
+ */
+bool time_sync_is_set(void);


### PR DESCRIPTION
## Summary

The ESP32-S3 has no battery-backed RTC, so on every cold boot `time(NULL)` returns 0 (Unix epoch) until something explicitly sets the clock. Today the only code path that sets the clock is the `get_current_time` tool ([main/tools/tool_get_time.c:54](main/tools/tool_get_time.c#L54)), which only runs when the LLM decides to call it.

That leaves every early-boot consumer of `time()` with bogus values until the user happens to message the bot:

- Session log / chat history timestamps start at 1970.
- Cron jobs that compare against `time(NULL)` may fire immediately or never.
- Any heartbeat or maintenance task that timestamps work on boot.

This PR adds a tiny `time_sync` module that starts SNTP against `pool.ntp.org` as soon as WiFi has an IP, applies `MIMI_TIMEZONE`, and exposes two helpers for callers that need to gate on a valid clock:

```c
esp_err_t time_sync_start(void);     // idempotent, non-blocking
bool      time_sync_wait(uint32_t timeout_ms);
bool      time_sync_is_set(void);    // same > 1700000000 threshold used today
```

## What's in the diff

- `main/time/time_sync.{h,c}` — new ~80-LoC module wrapping `esp_netif_sntp_init`.
- `main/CMakeLists.txt` — register the new source. `esp_netif` is already in `REQUIRES`, so no new component dependency.
- `main/mimi.c` — call `time_sync_start()` right after `wifi_manager_wait_connected()` succeeds (and only on that path, so onboarding-mode boots are unaffected).

SNTP runs in the background and logs `System time synchronized: ...` from the sync callback when the first sample arrives (typically 1–3 seconds after `WIFI_CONNECTED`). Calling `time_sync_start()` more than once is a no-op.

## Test plan

- [ ] Build: `idf.py fullclean && idf.py build`
- [ ] Flash and monitor: `idf.py -p <PORT> flash monitor`
- [ ] Confirm a `time_sync: System time synchronized: YYYY-MM-DD HH:MM:SS` log appears within ~5 s of `wifi: Connected!`
- [ ] Confirm session log filenames and any cron entries use a real date, not `1970-01-01`
- [ ] Disconnect WiFi temporarily then reconnect — SNTP re-syncs on its own (lwIP default is hourly)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented SNTP-based system time synchronization that initiates automatically after WiFi connection, ensuring the system clock is accurately set before time-sensitive services initialize.
  * Added timezone configuration support through environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->