### PR TITLE
feat: make MIMI_TIMEZONE configurable via mimi_secrets.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ Edit `main/mimi_secrets.h`:
 #define MIMI_SECRET_TAVILY_KEY      ""              // optional: Tavily API key (preferred)
 #define MIMI_SECRET_PROXY_HOST      ""              // optional: e.g. "10.0.0.1"
 #define MIMI_SECRET_PROXY_PORT      ""              // optional: e.g. "7897"
+#define MIMI_SECRET_TIMEZONE        "PST8PDT,..."   // optional: POSIX TZ for local timestamps
 ```
+
+> **Timezone.** `MIMI_SECRET_TIMEZONE` accepts any POSIX TZ string and defaults to US Pacific. Some common values: `"<-03>3"` for Brasília, `"WET0WEST,M3.5.0/1,M10.5.0"` for Lisbon, `"CET-1CEST,M3.5.0,M10.5.0/3"` for Berlin, `"JST-9"` for Tokyo. See [`tzset(3)`](https://man7.org/linux/man-pages/man3/tzset.3.html) for the full grammar. More examples in `main/mimi_secrets.h.example`.
 
 Then build and flash:
 

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -46,6 +46,9 @@
 #ifndef MIMI_SECRET_TAVILY_KEY
 #define MIMI_SECRET_TAVILY_KEY      ""
 #endif
+#ifndef MIMI_SECRET_TIMEZONE
+#define MIMI_SECRET_TIMEZONE        "PST8PDT,M3.2.0,M11.1.0"
+#endif
 
 /* WiFi */
 #define MIMI_WIFI_MAX_RETRY          10
@@ -79,8 +82,9 @@
 #define MIMI_MAX_TOOL_CALLS          4
 #define MIMI_AGENT_SEND_WORKING_STATUS 1
 
-/* Timezone (POSIX TZ format) */
-#define MIMI_TIMEZONE                "PST8PDT,M3.2.0,M11.1.0"
+/* Timezone (POSIX TZ format). Override per-device via MIMI_SECRET_TIMEZONE
+ * in mimi_secrets.h. Default keeps prior behaviour (US Pacific with DST). */
+#define MIMI_TIMEZONE                MIMI_SECRET_TIMEZONE
 
 /* LLM */
 #define MIMI_LLM_DEFAULT_MODEL       "claude-opus-4-5"

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -35,3 +35,16 @@
 #define MIMI_SECRET_SEARCH_KEY      ""
 /* Tavily Search API */
 #define MIMI_SECRET_TAVILY_KEY      ""
+
+/* Timezone in POSIX TZ format (used for all local timestamps).
+ * Default ("PST8PDT,M3.2.0,M11.1.0") is US Pacific with DST.
+ * Examples:
+ *   Brasília / São Paulo (UTC-3, no DST):  "<-03>3"
+ *   Lisbon / WET-WEST (UTC+0/+1 DST):      "WET0WEST,M3.5.0/1,M10.5.0"
+ *   London / GMT-BST (UTC+0/+1 DST):       "GMT0BST,M3.5.0/1,M10.5.0"
+ *   Berlin / CET-CEST (UTC+1/+2 DST):      "CET-1CEST,M3.5.0,M10.5.0/3"
+ *   Tokyo (UTC+9, no DST):                 "JST-9"
+ *   New York / EST-EDT (UTC-5/-4 DST):     "EST5EDT,M3.2.0,M11.1.0"
+ * Reference: https://man7.org/linux/man-pages/man3/tzset.3.html
+ */
+#define MIMI_SECRET_TIMEZONE        "PST8PDT,M3.2.0,M11.1.0"


### PR DESCRIPTION
## Summary

Today `MIMI_TIMEZONE` is hard-coded to US Pacific (`PST8PDT,M3.2.0,M11.1.0`) in `mimi_config.h`. Every local timestamp emitted by the firmware — session log filenames, agent context, tool output, the existing `get_current_time` tool, `localtime_r()` calls throughout — is therefore wrong by anywhere between 4 and 16 hours for users outside the US west coast. Fixing it requires editing a git-tracked file, which is easy to forget when pulling upstream and noisy in PR diffs.

This patch promotes the value to the existing build-time secrets layer:

```c
// mimi_config.h — secret fallback + alias
#ifndef MIMI_SECRET_TIMEZONE
#define MIMI_SECRET_TIMEZONE  "PST8PDT,M3.2.0,M11.1.0"
#endif
#define MIMI_TIMEZONE         MIMI_SECRET_TIMEZONE
```

Set `MIMI_SECRET_TIMEZONE` in `mimi_secrets.h` (gitignored, per-device) and you're done. Leave it unset and the default keeps the prior US Pacific value, so **no existing build behaves differently**.

## What's in the diff

- `main/mimi_config.h` — `MIMI_SECRET_TIMEZONE` with `#ifndef` fallback (same pattern as every other secret in the file) and `MIMI_TIMEZONE` aliased to it.
- `main/mimi_secrets.h.example` — documented `MIMI_SECRET_TIMEZONE` slot with worked POSIX TZ examples for Brasília, Lisbon, London, Berlin, Tokyo, New York, plus a link to `tzset(3)`.
- `README.md` — one-paragraph pointer in the "Configure" section.

No code-path changes: every caller already includes `mimi_config.h` and reads `MIMI_TIMEZONE`, so the substitution is transparent.

## Test plan

- [ ] Default build (no `mimi_secrets.h` override): `idf.py fullclean && idf.py build` succeeds, `MIMI_TIMEZONE` still expands to `"PST8PDT,M3.2.0,M11.1.0"`.
- [ ] Override build: set `MIMI_SECRET_TIMEZONE "<-03>3"` in `mimi_secrets.h`, rebuild, flash, and confirm `localtime_r()` output (e.g. via `get_current_time` tool or any session log) matches local wall-clock time in São Paulo.
- [ ] No new warnings from the preprocessor on either path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-device timezone customization. Devices can now be configured with custom POSIX TZ strings, enabling flexible timezone settings tailored to regional requirements instead of the default Pacific timezone.

* **Documentation**
  * Added detailed timezone configuration guidance including accepted TZ formats and reference documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->