### PR TITLE
feat: optional start anchor for recurring cron jobs

### DIFF
--- a/main/cron/cron_service.c
+++ b/main/cron/cron_service.c
@@ -315,7 +315,14 @@ static void compute_initial_next_run(cron_job_t *job)
     time_t now = time(NULL);
 
     if (job->kind == CRON_KIND_EVERY) {
-        job->next_run = now + job->interval_s;
+        /* Optional start anchor: if at_epoch is set and in the future, use it
+         * as the first fire time. Lets callers say "every 86400s starting at
+         * tomorrow 10:00 local time" instead of "now + 24h". */
+        if (job->at_epoch > now) {
+            job->next_run = job->at_epoch;
+        } else {
+            job->next_run = now + job->interval_s;
+        }
     } else if (job->kind == CRON_KIND_AT) {
         if (job->at_epoch > now) {
             job->next_run = job->at_epoch;

--- a/main/tools/tool_cron.c
+++ b/main/tools/tool_cron.c
@@ -64,6 +64,23 @@ esp_err_t tool_cron_add_execute(const char *input_json, char *output, size_t out
         }
         job.interval_s = (uint32_t)interval->valuedouble;
         job.delete_after_run = false;
+
+        /* Optional start anchor: if provided and in the future, the first
+         * fire happens at this timestamp instead of (now + interval_s).
+         * Subsequent fires follow interval_s as usual. */
+        cJSON *start_at = cJSON_GetObjectItem(root, "at_epoch");
+        if (start_at && cJSON_IsNumber(start_at)) {
+            int64_t anchor = (int64_t)start_at->valuedouble;
+            time_t now = time(NULL);
+            if (anchor <= now) {
+                snprintf(output, output_size,
+                         "Error: at_epoch %lld is not in the future (now=%lld)",
+                         (long long)anchor, (long long)now);
+                cJSON_Delete(root);
+                return ESP_ERR_INVALID_ARG;
+            }
+            job.at_epoch = anchor;
+        }
     } else if (strcmp(schedule_type, "at") == 0) {
         job.kind = CRON_KIND_AT;
         cJSON *at_epoch = cJSON_GetObjectItem(root, "at_epoch");
@@ -103,8 +120,10 @@ esp_err_t tool_cron_add_execute(const char *input_json, char *output, size_t out
     /* Format success response */
     if (job.kind == CRON_KIND_EVERY) {
         snprintf(output, output_size,
-                 "OK: Added recurring job '%s' (id=%s), runs every %lu seconds. Next run at epoch %lld.",
-                 job.name, job.id, (unsigned long)job.interval_s, (long long)job.next_run);
+                 "OK: Added recurring job '%s' (id=%s), runs every %lu seconds%s. Next run at epoch %lld.",
+                 job.name, job.id, (unsigned long)job.interval_s,
+                 job.at_epoch > 0 ? " starting at given anchor" : "",
+                 (long long)job.next_run);
     } else {
         snprintf(output, output_size,
                  "OK: Added one-shot job '%s' (id=%s), fires at epoch %lld.%s",

--- a/main/tools/tool_registry.c
+++ b/main/tools/tool_registry.c
@@ -143,7 +143,7 @@ esp_err_t tool_registry_init(void)
             "\"name\":{\"type\":\"string\",\"description\":\"Short name for the job\"},"
             "\"schedule_type\":{\"type\":\"string\",\"description\":\"'every' for recurring interval or 'at' for one-shot at a unix timestamp\"},"
             "\"interval_s\":{\"type\":\"integer\",\"description\":\"Interval in seconds (required for 'every')\"},"
-            "\"at_epoch\":{\"type\":\"integer\",\"description\":\"Unix timestamp to fire at (required for 'at')\"},"
+            "\"at_epoch\":{\"type\":\"integer\",\"description\":\"Unix timestamp. Required for 'at'. Optional for 'every' as a start anchor: the first fire happens at this future timestamp, subsequent fires follow interval_s. Use this to schedule recurring jobs aligned to a wall-clock time (e.g. every day at 10:00 local).\"},"
             "\"message\":{\"type\":\"string\",\"description\":\"Message to inject when the job fires, triggering an agent turn\"},"
             "\"channel\":{\"type\":\"string\",\"description\":\"Optional reply channel (e.g. 'telegram'). If omitted, current turn channel is used when available\"},"
             "\"chat_id\":{\"type\":\"string\",\"description\":\"Optional reply chat_id. Required when channel='telegram'. If omitted during a Telegram turn, current chat_id is used\"}"


### PR DESCRIPTION
## Summary

Today `schedule_type: "every"` always fires for the first time at `(now + interval_s)`. Practically this makes it impossible to schedule a recurring job aligned to a wall-clock time without writing a one-shot `"at"` job whose message re-creates itself on every fire — a fragile pattern that depends on the LLM remembering to chain `cron_add` again.

Concrete pain point I hit while configuring a daily routine on a real device: the user asked for "every weekday at 10:00 local time". The LLM correctly computed the epoch for the next 10:00, called `cron_add` with both `schedule_type: "every"` and `at_epoch: <future-ts>`, and the API silently ignored `at_epoch` — the job was scheduled for *now + 86400* (~3:26 AM local) instead. The first failure mode is silent, the second requires teaching the LLM a multi-step workaround, both are avoidable.

This PR lets callers pass `at_epoch` alongside `interval_s` for an `"every"` job. When set and in the future, the first fire happens at `at_epoch` and every subsequent fire follows `interval_s`. No behavior change for callers that only pass `interval_s`.

```diff
 if (job->kind == CRON_KIND_EVERY) {
-    job->next_run = now + job->interval_s;
+    if (job->at_epoch > now) {
+        job->next_run = job->at_epoch;   // honor caller-supplied anchor
+    } else {
+        job->next_run = now + job->interval_s;
+    }
 }
```

## What's in the diff

- `main/cron/cron_service.c` — `compute_initial_next_run()` honors `at_epoch` for `"every"` jobs when in the future.
- `main/tools/tool_cron.c` — `cron_add` reads optional `at_epoch` for `"every"`, validates it's in the future, stores it on the job.
- `main/tools/tool_registry.c` — the tool schema description for `at_epoch` now documents the new optional usage so the LLM discovers it through the tool catalogue rather than the user having to spell it out every time.

No new field on `cron_job_t`, no migration of `cron.json` on disk — `at_epoch` already existed for `"at"` jobs and was simply unused by `"every"` ones. Persisted jobs from before this change keep working unchanged.

## Test plan

- [ ] Existing callers: `cron_add({schedule_type:"every", interval_s:60, message:"x"})` still fires `now + 60s`, then every 60s after.
- [ ] New usage: `cron_add({schedule_type:"every", interval_s:86400, at_epoch:<tomorrow 10:00 UTC>, message:"x"})` first fires at the supplied timestamp, then every 24h after.
- [ ] Validation: `at_epoch` in the past for an `"every"` job returns the same "is in the past" error already used for `"at"` jobs.
- [ ] Persistence: an `"every"` job created with `at_epoch` survives a reboot with the right `next_run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recurring jobs can now be scheduled with an optional start time anchor, allowing specification of when the first execution occurs while subsequent runs follow the regular interval.

* **Documentation**
  * Updated scheduling documentation to explain the new start time anchoring feature, clarifying requirements for one-time jobs and optional usage for recurring jobs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->