### PR TITLE
fix(llm_proxy): exempt task from TWDT during blocking HTTP call

### DIFF
--- a/main/llm/llm_proxy.c
+++ b/main/llm/llm_proxy.c
@@ -8,6 +8,7 @@
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
 #include "esp_heap_caps.h"
+#include "esp_task_wdt.h"
 #include "nvs.h"
 #include "cJSON.h"
 
@@ -277,7 +278,12 @@ static esp_err_t llm_http_direct(const char *post_data, resp_buf_t *rb, int *out
     }
     esp_http_client_set_post_field(client, post_data, strlen(post_data));
 
+    bool wdt_was_subscribed = (esp_task_wdt_delete(NULL) == ESP_OK);
     esp_err_t err = esp_http_client_perform(client);
+    if (wdt_was_subscribed) {
+        esp_task_wdt_add(NULL);
+        esp_task_wdt_reset();
+    }
     *out_status = esp_http_client_get_status_code(client);
     esp_http_client_cleanup(client);
     return err;
@@ -322,10 +328,15 @@ static esp_err_t llm_http_via_proxy(const char *post_data, resp_buf_t *rb, int *
 
     /* Read full response into buffer */
     char tmp[4096];
+    bool wdt_was_subscribed = (esp_task_wdt_delete(NULL) == ESP_OK);
     while (1) {
         int n = proxy_conn_read(conn, tmp, sizeof(tmp), 120000);
         if (n <= 0) break;
         if (resp_buf_append(rb, tmp, n) != ESP_OK) break;
+    }
+    if (wdt_was_subscribed) {
+        esp_task_wdt_add(NULL);
+        esp_task_wdt_reset();
     }
     proxy_conn_close(conn);
 


### PR DESCRIPTION
## Summary
Fixes WDT-triggered hard resets during slow LLM responses. Removes the task from TWDT monitoring for the duration of the blocking HTTP call, on both the direct and proxy paths.

## Problem

Calling `esp_task_wdt_reset()` before and after `esp_http_client_perform()` does not work. A task parked in a locking call cannot execute any code, watchdog resets. 

Ask MimiClaw to summarize a long document. The LLM accepts the connection but takes 18s to generate the response. The TWDT fires at t=5s the call, `abort()` is called, and the chip resets cold. The user sees startup blink sequence mid-conversation, session gone. UART shows rst:0xc (SW_CPU_RESET)`. The post-call reset never executes.

## Fix

`esp_task_wdt_delete(NULL)` removes the calling task from TWDT monitoring the blocking call. `esp_task_wdt_add(NULL)` and `esp_task_wdt_reset()` restore it after. `wdt_was_subscribed` guards against accidentally subscribing the task if it was not previously registered. Applied to both `llm_http_direct` and `llm_http_via_proxy`.

## Validation

- idf.py build passes on v5.5.2, target esp32s3.
> Note: Builds on v5.5.0/v5.5.1 require PR #181 (websocket dependency fix) to be merged first.
- Flashed to ESP32-S3 dev board, asked MimiClaw a multi-step reasoning question. Previous firmware rebooted mid-response with `rst:0xc`. With this fix the response completed in 23 s without a reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced application stability during network operations by preventing unexpected timeouts that could occur during extended HTTP communication. Improved handling of blocking network requests provides greater reliability during slow or unstable network conditions, reducing potential application crashes and unexpected restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/memovai/mimiclaw/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->