### PR TITLE
Add fallback for reasoning model responses

### DIFF
--- a/main/llm/llm_proxy.c
+++ b/main/llm/llm_proxy.c
@@ -647,6 +647,16 @@ esp_err_t llm_chat_tools(const char *system_prompt,
             cJSON *message = cJSON_GetObjectItem(choice0, "message");
             if (message) {
                 cJSON *content = cJSON_GetObjectItem(message, "content");
+                /* Fallback for reasoning models (DeepSeek, Kimi, vLLM) */
+                if (!(content && cJSON_IsString(content) && content->valuestring[0])) {
+                    cJSON *tcs = cJSON_GetObjectItem(message, "tool_calls");
+                    bool has_tools = tcs && cJSON_IsArray(tcs) && cJSON_GetArraySize(tcs) > 0;
+                    if (!has_tools) {
+                        content = cJSON_GetObjectItem(message, "reasoning_content");
+                        if (!(content && cJSON_IsString(content) && content->valuestring[0]))
+                            content = cJSON_GetObjectItem(message, "reasoning");
+                    }
+                }
                 if (content && cJSON_IsString(content)) {
                     size_t tlen = strlen(content->valuestring);
                     resp->text = calloc(1, tlen + 1);


### PR DESCRIPTION
## Summary
Reasoning models like DeepSeek, Kimi or vLLM put their text in `reasoning_content` or `reasoning` and leave `content` null. The parser only reads `content`, so the bot stays silent while the API call succeeds and tokens get billed.

## How this is hit
Stock builds point at api.openai.com, which never returns these fields. It shows up when `MIMI_OPENAI_API_URL` is changed to an OpenAI-compatible endpoint serving a reasoning model. Once provider expansion lands (#67, requested in #184) this path is reachable without config edits.

## Fix
When `content` is null or empty and the message has no tool calls, fall back to `reasoning_content`, then `reasoning`.
The tool call check matters. A model making a tool call returns `content: null` with `tool_calls` set, which is normal. Without the guard the fallback would put chain-of-thought into the reply on every tool call turn. With it, standard models and tool calling behave as before.

One known gap: if the model hits `MIMI_LLM_MAX_TOKENS` (4096) while thinking, the fallback returns truncated reasoning text. Better than a silent reply, but raising the cap is a separate fix.

## What's in the diff
- `main/llm/llm_proxy.c`: guarded fallback in the openai response parser, 10 lines

## Validation
`idf.py build` passes on ESP-IDF v5.5.2, target esp32s3. The fallback only runs when `content` is empty and no tool calls are present.

## Related
- #184 (DeepSeek support request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced response handling for reasoning-style language models. System now implements fallback mechanisms to provide complete and reliable output when expected response content fields are unavailable or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->