### PR TITLE
feat(llm): add MiniMax provider with global/China regional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You send a message on Telegram. The ESP32-S3 picks it up over WiFi, feeds it int
 - An **ESP32-S3 dev board** with 16 MB flash and 8 MB PSRAM (e.g. Xiaozhi AI board, ~$10)
 - A **USB Type-C cable**
 - A **Telegram bot token** — talk to [@BotFather](https://t.me/BotFather) on Telegram to create one
-- An **Anthropic API key** — from [console.anthropic.com](https://console.anthropic.com), or an **OpenAI API key** — from [platform.openai.com](https://platform.openai.com)
+- An **Anthropic API key** — from [console.anthropic.com](https://console.anthropic.com), an **OpenAI API key** — from [platform.openai.com](https://platform.openai.com), or a **MiniMax API key** — from [platform.minimax.io](https://platform.minimax.io) (global) or [platform.minimaxi.com](https://platform.minimaxi.com) (China); MiniMax exposes an OpenAI-compatible endpoint, default model `MiniMax-M3` (`MiniMax-M2.7` also available)
 
 ### Install
 
@@ -128,7 +128,7 @@ Edit `main/mimi_secrets.h`:
 #define MIMI_SECRET_WIFI_PASS       "YourWiFiPassword"
 #define MIMI_SECRET_TG_TOKEN        "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
 #define MIMI_SECRET_API_KEY         "sk-ant-api03-xxxxx"
-#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic" or "openai"
+#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic", "openai", or "minimax"
 #define MIMI_SECRET_SEARCH_KEY      ""              // optional: Brave Search API key
 #define MIMI_SECRET_TAVILY_KEY      ""              // optional: Tavily API key (preferred)
 #define MIMI_SECRET_PROXY_HOST      ""              // optional: e.g. "10.0.0.1"
@@ -169,8 +169,10 @@ Connect via serial to configure or debug. **Config commands** let you change set
 mimi> wifi_set MySSID MyPassword   # change WiFi network
 mimi> set_tg_token 123456:ABC...   # change Telegram bot token
 mimi> set_api_key sk-ant-api03-... # change API key (Anthropic or OpenAI)
-mimi> set_model_provider openai    # switch provider (anthropic|openai)
+mimi> set_model_provider openai    # switch provider (anthropic|openai|minimax)
 mimi> set_model gpt-4o             # change LLM model
+mimi> set_model MiniMax-M3         # MiniMax default (also: MiniMax-M2.7)
+mimi> set_minimax_region cn_zh     # MiniMax region (global_en|cn_zh)
 mimi> set_proxy 127.0.0.1 7897  # set HTTP proxy
 mimi> clear_proxy                  # remove proxy
 mimi> set_search_key BSA...        # set Brave Search API key

--- a/README_CN.md
+++ b/README_CN.md
@@ -40,7 +40,7 @@ MimiClaw 把一块小小的 ESP32-S3 开发板变成你的私人 AI 助理。插
 - 一块 **ESP32-S3 开发板**，16MB Flash + 8MB PSRAM（如小智 AI 开发板，~¥30）
 - 一根 **USB Type-C 数据线**
 - 一个 **Telegram Bot Token** — 在 Telegram 找 [@BotFather](https://t.me/BotFather) 创建
-- 一个 **Anthropic API Key** — 从 [console.anthropic.com](https://console.anthropic.com) 获取，或一个 **OpenAI API Key** — 从 [platform.openai.com](https://platform.openai.com) 获取
+- 一个 **Anthropic API Key** — 从 [console.anthropic.com](https://console.anthropic.com) 获取，一个 **OpenAI API Key** — 从 [platform.openai.com](https://platform.openai.com) 获取，或一个 **MiniMax API Key** — 从 [platform.minimax.io](https://platform.minimax.io)（全球）或 [platform.minimaxi.com](https://platform.minimaxi.com)（中国）获取；MiniMax 提供 OpenAI 兼容接口，默认模型 `MiniMax-M3`（另有 `MiniMax-M2.7` 可选）
 
 ### 安装
 
@@ -128,7 +128,7 @@ cp main/mimi_secrets.h.example main/mimi_secrets.h
 #define MIMI_SECRET_WIFI_PASS       "你的WiFi密码"
 #define MIMI_SECRET_TG_TOKEN        "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
 #define MIMI_SECRET_API_KEY         "sk-ant-api03-xxxxx"
-#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic" 或 "openai"
+#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic"、"openai" 或 "minimax"
 #define MIMI_SECRET_SEARCH_KEY      ""              // 可选：Brave Search API key
 #define MIMI_SECRET_TAVILY_KEY      ""              // 可选：Tavily API key（优先）
 #define MIMI_SECRET_PROXY_HOST      "10.0.0.1"      // 可选：代理地址
@@ -184,8 +184,10 @@ mimi> clear_proxy                    # 清除代理
 mimi> wifi_set MySSID MyPassword   # 换 WiFi
 mimi> set_tg_token 123456:ABC...   # 换 Telegram Bot Token
 mimi> set_api_key sk-ant-api03-... # 换 API Key（Anthropic 或 OpenAI）
-mimi> set_model_provider openai    # 切换提供商（anthropic|openai）
+mimi> set_model_provider openai    # 切换提供商（anthropic|openai|minimax）
 mimi> set_model gpt-4o             # 换模型
+mimi> set_model MiniMax-M3         # MiniMax 默认模型（也支持 MiniMax-M2.7）
+mimi> set_minimax_region cn_zh     # MiniMax 区域（global_en|cn_zh）
 mimi> set_proxy 192.168.1.83 7897  # 设置代理
 mimi> clear_proxy                  # 清除代理
 mimi> set_search_key BSA...        # 设置 Brave Search API Key

--- a/README_JA.md
+++ b/README_JA.md
@@ -40,7 +40,7 @@ Telegramでメッセージを送ると、ESP32-S3がWiFi経由で受信し、エ
 - **ESP32-S3開発ボード**（16MB Flash + 8MB PSRAM搭載、例：小智AIボード、約$10）
 - **USB Type-Cケーブル**
 - **Telegram Botトークン** — Telegramで[@BotFather](https://t.me/BotFather)に話しかけて作成
-- **Anthropic APIキー** — [console.anthropic.com](https://console.anthropic.com)から取得、または **OpenAI APIキー** — [platform.openai.com](https://platform.openai.com)から取得
+- **Anthropic APIキー** — [console.anthropic.com](https://console.anthropic.com)から取得、**OpenAI APIキー** — [platform.openai.com](https://platform.openai.com)から取得、または **MiniMax APIキー** — [platform.minimax.io](https://platform.minimax.io)（グローバル）/ [platform.minimaxi.com](https://platform.minimaxi.com)（中国）から取得（MiniMaxはOpenAI互換エンドポイントを提供。デフォルトモデルは `MiniMax-M3`、`MiniMax-M2.7` も選択可能）
 
 ### インストール
 
@@ -128,7 +128,7 @@ cp main/mimi_secrets.h.example main/mimi_secrets.h
 #define MIMI_SECRET_WIFI_PASS       "WiFiパスワード"
 #define MIMI_SECRET_TG_TOKEN        "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
 #define MIMI_SECRET_API_KEY         "sk-ant-api03-xxxxx"
-#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic" または "openai"
+#define MIMI_SECRET_MODEL_PROVIDER  "anthropic"     // "anthropic"、"openai"、または "minimax"
 #define MIMI_SECRET_SEARCH_KEY      ""              // 任意：Brave Search APIキー
 #define MIMI_SECRET_TAVILY_KEY      ""              // 任意：Tavily APIキー（優先）
 #define MIMI_SECRET_PROXY_HOST      ""              // 任意：例 "10.0.0.1"
@@ -169,8 +169,10 @@ idf.py -p PORT flash monitor
 mimi> wifi_set MySSID MyPassword   # WiFiネットワークを変更
 mimi> set_tg_token 123456:ABC...   # Telegram Botトークンを変更
 mimi> set_api_key sk-ant-api03-... # APIキーを変更（AnthropicまたはOpenAI）
-mimi> set_model_provider openai    # プロバイダーを切替（anthropic|openai）
+mimi> set_model_provider openai    # プロバイダーを切替（anthropic|openai|minimax）
 mimi> set_model gpt-4o             # LLMモデルを変更
+mimi> set_model MiniMax-M3         # MiniMaxデフォルトモデル（MiniMax-M2.7も選択可）
+mimi> set_minimax_region cn_zh     # MiniMaxリージョン（global_en|cn_zh）
 mimi> set_proxy 127.0.0.1 7897    # HTTPプロキシを設定
 mimi> clear_proxy                  # プロキシを削除
 mimi> set_search_key BSA...        # Brave Search APIキーを設定

--- a/main/cli/serial_cli.c
+++ b/main/cli/serial_cli.c
@@ -171,6 +171,24 @@ static int cmd_set_model_provider(int argc, char **argv)
     return 0;
 }
 
+/* --- set_minimax_region command --- */
+static struct {
+    struct arg_str *region;
+    struct arg_end *end;
+} minimax_region_args;
+
+static int cmd_set_minimax_region(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&minimax_region_args);
+    if (nerrors != 0) {
+        arg_print_errors(stderr, minimax_region_args.end, argv[0]);
+        return 1;
+    }
+    llm_set_minimax_region(minimax_region_args.region->sval[0]);
+    printf("MiniMax region set.\n");
+    return 0;
+}
+
 /* --- memory_read command --- */
 static int cmd_memory_read(int argc, char **argv)
 {
@@ -887,7 +905,7 @@ esp_err_t serial_cli_init(void)
     esp_console_cmd_register(&model_cmd);
 
     /* set_model_provider */
-    provider_args.provider = arg_str1(NULL, NULL, "<provider>", "Model provider (anthropic|openai)");
+    provider_args.provider = arg_str1(NULL, NULL, "<provider>", "Model provider (anthropic|openai|minimax)");
     provider_args.end = arg_end(1);
     esp_console_cmd_t provider_cmd = {
         .command = "set_model_provider",
@@ -896,6 +914,17 @@ esp_err_t serial_cli_init(void)
         .argtable = &provider_args,
     };
     esp_console_cmd_register(&provider_cmd);
+
+    /* set_minimax_region */
+    minimax_region_args.region = arg_str1(NULL, NULL, "<region>", "MiniMax region (global_en|cn_zh)");
+    minimax_region_args.end = arg_end(1);
+    esp_console_cmd_t minimax_region_cmd = {
+        .command = "set_minimax_region",
+        .help = "Set MiniMax API region (default: " MIMI_MINIMAX_REGION_DEFAULT ")",
+        .func = &cmd_set_minimax_region,
+        .argtable = &minimax_region_args,
+    };
+    esp_console_cmd_register(&minimax_region_cmd);
 
     /* skill_list */
     esp_console_cmd_t skill_list_cmd = {

--- a/main/llm/llm_proxy.c
+++ b/main/llm/llm_proxy.c
@@ -15,12 +15,14 @@ static const char *TAG = "llm";
 
 #define LLM_API_KEY_MAX_LEN 320
 #define LLM_MODEL_MAX_LEN   64
+#define LLM_REGION_MAX_LEN  16
 #define LLM_DUMP_MAX_BYTES   (16 * 1024)
 #define LLM_DUMP_CHUNK_BYTES 320
 
 static char s_api_key[LLM_API_KEY_MAX_LEN] = {0};
 static char s_model[LLM_MODEL_MAX_LEN] = MIMI_LLM_DEFAULT_MODEL;
 static char s_provider[16] = MIMI_LLM_PROVIDER_DEFAULT;
+static char s_minimax_region[LLM_REGION_MAX_LEN] = MIMI_MINIMAX_REGION_DEFAULT;
 
 static void llm_log_payload(const char *label, const char *payload)
 {
@@ -187,18 +189,47 @@ static bool provider_is_openai(void)
     return strcmp(s_provider, "openai") == 0;
 }
 
+static bool provider_is_minimax(void)
+{
+    return strcmp(s_provider, "minimax") == 0;
+}
+
+/* MiniMax speaks the OpenAI-compatible chat-completions protocol, so every
+ * branch that asks "is this provider OpenAI-shaped?" must also count MiniMax. */
+static bool provider_is_openai_compat(void)
+{
+    return provider_is_openai() || provider_is_minimax();
+}
+
+/* MiniMax is reachable through two regional endpoints selected at runtime:
+ * "global_en" (api.minimax.io) and "cn_zh" (api.minimaxi.com). Any value other
+ * than "cn_zh" falls back to the global endpoint. */
+static bool minimax_region_is_cn(void)
+{
+    return strcmp(s_minimax_region, "cn_zh") == 0;
+}
+
 static const char *llm_api_url(void)
 {
+    if (provider_is_minimax()) {
+        return minimax_region_is_cn() ? MIMI_MINIMAX_API_URL_CN
+                                       : MIMI_MINIMAX_API_URL_GLOBAL;
+    }
     return provider_is_openai() ? MIMI_OPENAI_API_URL : MIMI_LLM_API_URL;
 }
 
 static const char *llm_api_host(void)
 {
+    if (provider_is_minimax()) {
+        return minimax_region_is_cn() ? MIMI_MINIMAX_API_HOST_CN
+                                       : MIMI_MINIMAX_API_HOST_GLOBAL;
+    }
     return provider_is_openai() ? "api.openai.com" : "api.anthropic.com";
 }
 
 static const char *llm_api_path(void)
 {
+    if (provider_is_minimax()) return MIMI_MINIMAX_API_PATH;
     return provider_is_openai() ? "/v1/chat/completions" : "/v1/messages";
 }
 
@@ -215,6 +246,9 @@ esp_err_t llm_proxy_init(void)
     }
     if (MIMI_SECRET_MODEL_PROVIDER[0] != '\0') {
         safe_copy(s_provider, sizeof(s_provider), MIMI_SECRET_MODEL_PROVIDER);
+    }
+    if (MIMI_SECRET_MINIMAX_REGION[0] != '\0') {
+        safe_copy(s_minimax_region, sizeof(s_minimax_region), MIMI_SECRET_MINIMAX_REGION);
     }
 
     /* NVS overrides take highest priority (set via CLI) */
@@ -235,11 +269,21 @@ esp_err_t llm_proxy_init(void)
         if (nvs_get_str(nvs, MIMI_NVS_KEY_PROVIDER, provider_tmp, &len) == ESP_OK && provider_tmp[0]) {
             safe_copy(s_provider, sizeof(s_provider), provider_tmp);
         }
+        char region_tmp[LLM_REGION_MAX_LEN] = {0};
+        len = sizeof(region_tmp);
+        if (nvs_get_str(nvs, MIMI_NVS_KEY_MINIMAX_REGION, region_tmp, &len) == ESP_OK && region_tmp[0]) {
+            safe_copy(s_minimax_region, sizeof(s_minimax_region), region_tmp);
+        }
         nvs_close(nvs);
     }
 
     if (s_api_key[0]) {
-        ESP_LOGI(TAG, "LLM proxy initialized (provider: %s, model: %s)", s_provider, s_model);
+        if (provider_is_minimax()) {
+            ESP_LOGI(TAG, "LLM proxy initialized (provider: %s, region: %s, model: %s)",
+                     s_provider, s_minimax_region, s_model);
+        } else {
+            ESP_LOGI(TAG, "LLM proxy initialized (provider: %s, model: %s)", s_provider, s_model);
+        }
     } else {
         ESP_LOGW(TAG, "No API key. Use CLI: set_api_key <KEY>");
     }
@@ -265,7 +309,7 @@ static esp_err_t llm_http_direct(const char *post_data, resp_buf_t *rb, int *out
 
     esp_http_client_set_method(client, HTTP_METHOD_POST);
     esp_http_client_set_header(client, "Content-Type", "application/json");
-    if (provider_is_openai()) {
+    if (provider_is_openai_compat()) {
         if (s_api_key[0]) {
             char auth[LLM_API_KEY_MAX_LEN + 16];
             snprintf(auth, sizeof(auth), "Bearer %s", s_api_key);
@@ -293,7 +337,7 @@ static esp_err_t llm_http_via_proxy(const char *post_data, resp_buf_t *rb, int *
     int body_len = strlen(post_data);
     char header[1024];
     int hlen = 0;
-    if (provider_is_openai()) {
+    if (provider_is_openai_compat()) {
         hlen = snprintf(header, sizeof(header),
             "POST %s HTTP/1.1\r\n"
             "Host: %s\r\n"
@@ -559,13 +603,13 @@ esp_err_t llm_chat_tools(const char *system_prompt,
     /* Build request body (non-streaming) */
     cJSON *body = cJSON_CreateObject();
     cJSON_AddStringToObject(body, "model", s_model);
-    if (provider_is_openai()) {
+    if (provider_is_openai_compat()) {
         cJSON_AddNumberToObject(body, "max_completion_tokens", MIMI_LLM_MAX_TOKENS);
     } else {
         cJSON_AddNumberToObject(body, "max_tokens", MIMI_LLM_MAX_TOKENS);
     }
 
-    if (provider_is_openai()) {
+    if (provider_is_openai_compat()) {
         cJSON *openai_msgs = convert_messages_openai(system_prompt, messages);
         cJSON_AddItemToObject(body, "messages", openai_msgs);
 
@@ -635,7 +679,7 @@ esp_err_t llm_chat_tools(const char *system_prompt,
         return ESP_FAIL;
     }
 
-    if (provider_is_openai()) {
+    if (provider_is_openai_compat()) {
         cJSON *choices = cJSON_GetObjectItem(root, "choices");
         cJSON *choice0 = choices && cJSON_IsArray(choices) ? cJSON_GetArrayItem(choices, 0) : NULL;
         if (choice0) {
@@ -807,5 +851,18 @@ esp_err_t llm_set_provider(const char *provider)
 
     safe_copy(s_provider, sizeof(s_provider), provider);
     ESP_LOGI(TAG, "Provider set to: %s", s_provider);
+    return ESP_OK;
+}
+
+esp_err_t llm_set_minimax_region(const char *region)
+{
+    nvs_handle_t nvs;
+    ESP_ERROR_CHECK(nvs_open(MIMI_NVS_LLM, NVS_READWRITE, &nvs));
+    ESP_ERROR_CHECK(nvs_set_str(nvs, MIMI_NVS_KEY_MINIMAX_REGION, region));
+    ESP_ERROR_CHECK(nvs_commit(nvs));
+    nvs_close(nvs);
+
+    safe_copy(s_minimax_region, sizeof(s_minimax_region), region);
+    ESP_LOGI(TAG, "MiniMax region set to: %s", s_minimax_region);
     return ESP_OK;
 }

--- a/main/llm/llm_proxy.h
+++ b/main/llm/llm_proxy.h
@@ -27,6 +27,12 @@ esp_err_t llm_set_provider(const char *provider);
  */
 esp_err_t llm_set_model(const char *model);
 
+/**
+ * Save the MiniMax region to NVS. ("global_en" -> api.minimax.io,
+ * "cn_zh" -> api.minimaxi.com). Only affects the MiniMax provider.
+ */
+esp_err_t llm_set_minimax_region(const char *region);
+
 /* ── Tool Use Support ──────────────────────────────────────────── */
 
 typedef struct {

--- a/main/mimi_config.h
+++ b/main/mimi_config.h
@@ -25,6 +25,9 @@
 #ifndef MIMI_SECRET_MODEL_PROVIDER
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
 #endif
+#ifndef MIMI_SECRET_MINIMAX_REGION
+#define MIMI_SECRET_MINIMAX_REGION  "global_en"
+#endif
 #ifndef MIMI_SECRET_PROXY_HOST
 #define MIMI_SECRET_PROXY_HOST      ""
 #endif
@@ -88,6 +91,16 @@
 #define MIMI_LLM_MAX_TOKENS          4096
 #define MIMI_LLM_API_URL             "https://api.anthropic.com/v1/messages"
 #define MIMI_OPENAI_API_URL          "https://api.openai.com/v1/chat/completions"
+/* MiniMax — OpenAI-compatible endpoint. Two regions are available and selected
+ * at runtime: "global_en" (api.minimax.io) and "cn_zh" (api.minimaxi.com).
+ * Default model is MiniMax-M3, with MiniMax-M2.7 as an alternative. */
+#define MIMI_MINIMAX_DEFAULT_MODEL   "MiniMax-M3"
+#define MIMI_MINIMAX_REGION_DEFAULT  "global_en"
+#define MIMI_MINIMAX_API_URL_GLOBAL  "https://api.minimax.io/v1/chat/completions"
+#define MIMI_MINIMAX_API_URL_CN      "https://api.minimaxi.com/v1/chat/completions"
+#define MIMI_MINIMAX_API_HOST_GLOBAL "api.minimax.io"
+#define MIMI_MINIMAX_API_HOST_CN     "api.minimaxi.com"
+#define MIMI_MINIMAX_API_PATH        "/v1/chat/completions"
 #define MIMI_LLM_API_VERSION         "2023-06-01"
 #define MIMI_LLM_STREAM_BUF_SIZE     (32 * 1024)
 #define MIMI_LLM_LOG_VERBOSE_PAYLOAD 0
@@ -150,6 +163,7 @@
 #define MIMI_NVS_KEY_TAVILY_KEY      "tavily_key"
 #define MIMI_NVS_KEY_MODEL           "model"
 #define MIMI_NVS_KEY_PROVIDER        "provider"
+#define MIMI_NVS_KEY_MINIMAX_REGION  "mm_region"
 #define MIMI_NVS_KEY_PROXY_HOST      "host"
 #define MIMI_NVS_KEY_PROXY_PORT      "port"
 #define MIMI_NVS_KEY_PROXY_TYPE      "proxy_type"

--- a/main/mimi_secrets.h.example
+++ b/main/mimi_secrets.h.example
@@ -21,10 +21,28 @@
 #define MIMI_SECRET_FEISHU_APP_ID   ""
 #define MIMI_SECRET_FEISHU_APP_SECRET ""
 
-/* Anthropic API */
+/* LLM API */
 #define MIMI_SECRET_API_KEY         ""
 #define MIMI_SECRET_MODEL           ""
 #define MIMI_SECRET_MODEL_PROVIDER  "anthropic"
+
+/* Provider examples:
+ *
+ *   Anthropic:  set_model_provider anthropic
+ *               set_model claude-opus-4-5
+ *
+ *   OpenAI:     set_model_provider openai
+ *               set_model gpt-4o
+ *
+ *   MiniMax:    set_model_provider minimax
+ *               set_model MiniMax-M3     (default; MiniMax-M2.7 also available)
+ *               set_minimax_region global_en   (api.minimax.io, default)
+ *               set_minimax_region cn_zh        (api.minimaxi.com)
+ *
+ *   MiniMax exposes an OpenAI-compatible endpoint; get a key from
+ *   https://platform.minimax.io (global) or https://platform.minimaxi.com (CN).
+ */
+#define MIMI_SECRET_MINIMAX_REGION  "global_en"   /* "global_en" or "cn_zh" */
 
 /* HTTP Proxy (leave empty or set both) */
 #define MIMI_SECRET_PROXY_HOST      ""


### PR DESCRIPTION
Reason: The firmware's LLM transport supported only Anthropic and OpenAI, with no MiniMax provider or China/global regional endpoint selection.

## What this adds

Adds **MiniMax** as a first-class LLM provider. MiniMax exposes an OpenAI-compatible chat-completions API, so it reuses the existing OpenAI-shaped request conversion, tool-call handling, and response parsing. The provider is reachable through two regional endpoints selected at runtime:

- `global_en` -> `https://api.minimax.io/v1/chat/completions` (default)
- `cn_zh` -> `https://api.minimaxi.com/v1/chat/completions`

The default model is `MiniMax-M3`, with `MiniMax-M2.7` available as an alternative.

## Changes

- `main/mimi_config.h`: MiniMax endpoint macros for both regions (URL, host, path), default model, default region, region secret default, and an NVS key for the region.
- `main/llm/llm_proxy.c`:
  - `provider_is_minimax()` and `provider_is_openai_compat()` so every OpenAI-shaped branch (auth header, request body, response parsing) also covers MiniMax.
  - `minimax_region_is_cn()` plus region-aware `llm_api_url()` / `llm_api_host()` / `llm_api_path()`.
  - Region loaded from the build-time secret then overridden by NVS, mirroring the existing provider/model handling.
  - `llm_set_minimax_region()` to persist the region to NVS.
- `main/llm/llm_proxy.h`: declaration for `llm_set_minimax_region()`.
- `main/cli/serial_cli.c`: `set_minimax_region <global_en|cn_zh>` command; `set_model_provider` help updated to list `minimax`.
- `main/mimi_secrets.h.example`: MiniMax provider/region configuration example.
- `README.md`, `README_CN.md`, `README_JA.md`: document the MiniMax provider, its models, and regional selection.

Any region value other than `cn_zh` falls back to the global endpoint. Anthropic and OpenAI behavior is unchanged.

## Checks

- Host-compiled a standalone harness that includes the real `main/mimi_config.h` and exercises the region-selection helpers (`gcc -Wall -Wextra`): verified `global_en`/default -> `api.minimax.io` and `cn_zh` -> `api.minimaxi.com` for both host and full URL, and that Anthropic/OpenAI selection is unaffected by the region. All assertions passed.

Note: the full ESP-IDF firmware build was not run because the ESP-IDF / Xtensa toolchain is not available in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported LLM provider.
  * Added support for MiniMax models, region-specific endpoints, and configurable regions.
  * Added a CLI command to select the MiniMax region at runtime.
  * Added support for saving MiniMax region settings for future use.

* **Documentation**
  * Updated English, Chinese, and Japanese setup guides with MiniMax configuration, model, API key, and CLI instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->